### PR TITLE
Use base32-encoded hashes to normalize names of signal APIs.

### DIFF
--- a/cmd/generate-animal-apis/encoding.go
+++ b/cmd/generate-animal-apis/encoding.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"crypto/sha1"
+	"encoding/base32"
+	"strings"
+)
+
+// Encode a name as its base32-encoded SHA1 hash to normalize its length.
+// The result is 32 character string (160 bits/5 bits-per-character).
+// Return values are lower-cased for readability and consistency with a
+// preference for lower-cased IDs.
+func encodeName(name string) string {
+	hash := sha1.New()
+	hash.Write([]byte(name))
+	return strings.ToLower(base32.StdEncoding.EncodeToString(hash.Sum(nil)))
+}

--- a/cmd/generate-animal-apis/runtime.go
+++ b/cmd/generate-animal-apis/runtime.go
@@ -78,7 +78,7 @@ func generateRuntimeMocks(animal *Animal) error {
 	if err != nil {
 		return err
 	}
-	proxyApiID := source + "-" + organization + "-proxy-" + enrolledApiID
+	proxyApiID := source + "-" + encodeName(organization+"-proxy-"+enrolledApiID)
 	proxy := &encoding.Api{
 		Header: encoding.Header{
 			ApiVersion: "apigeeregistry/v1",
@@ -170,7 +170,7 @@ func generateRuntimeMocks(animal *Animal) error {
 	if err != nil {
 		return err
 	}
-	productApiID := source + "-" + organization + "-product-" + enrolledApiID
+	productApiID := source + "-" + encodeName(organization+"-product-"+enrolledApiID)
 	product := &encoding.Api{
 		Header: encoding.Header{
 			ApiVersion: "apigeeregistry/v1",

--- a/cmd/generate-animal-apis/traffic.go
+++ b/cmd/generate-animal-apis/traffic.go
@@ -59,7 +59,7 @@ func generateTraffic(id int, animal *Animal) error {
 
 	enrolledApiID := provider + "-" + strings.ToLower(lowerPlural)
 
-	trafficApiID := source + "-" + organization + "-traffic-" + trafficID
+	trafficApiID := source + "-" + encodeName(organization+"-traffic-"+trafficID)
 	fmt.Printf("generating %+v API\n", trafficApiID)
 
 	// Create output directory.

--- a/runtime/aardvarks/info.yaml
+++ b/runtime/aardvarks/info.yaml
@@ -3,7 +3,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-proxy-fauna-aardvarks
+      name: generate-animal-apis-ytikblczmnmc5wfn7wx2a62v2k677cqr
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
@@ -41,7 +41,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-product-fauna-aardvarks
+      name: generate-animal-apis-da7sm7js3vlv25kbcjmzovv3zgdwpgmr
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
@@ -69,7 +69,7 @@ items:
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
                 category: apihub-organization-apis
-                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-apigee-apihub-demo-proxy-fauna-aardvarks
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-ytikblczmnmc5wfn7wx2a62v2k677cqr
                 uri: ""
         - kind: ReferenceList
           metadata:

--- a/runtime/bandicoots/info.yaml
+++ b/runtime/bandicoots/info.yaml
@@ -3,7 +3,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-proxy-fauna-bandicoots
+      name: generate-animal-apis-4vajvc52av2p4te5llvmbqjjhvgewdw6
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
@@ -41,7 +41,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-product-fauna-bandicoots
+      name: generate-animal-apis-bxfb5toykhtghq3itral2cxw6uipqy3q
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
@@ -69,7 +69,7 @@ items:
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
                 category: apihub-organization-apis
-                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-apigee-apihub-demo-proxy-fauna-bandicoots
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-4vajvc52av2p4te5llvmbqjjhvgewdw6
                 uri: ""
         - kind: ReferenceList
           metadata:

--- a/runtime/crocodiles/info.yaml
+++ b/runtime/crocodiles/info.yaml
@@ -3,7 +3,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-proxy-fauna-crocodiles
+      name: generate-animal-apis-xqxklnlxqea7vxvt7tahs6wgsoouw4lo
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
@@ -41,7 +41,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-product-fauna-crocodiles
+      name: generate-animal-apis-grsvj26uatbtd2iirg23p4ucbvjjbmfw
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
@@ -69,7 +69,7 @@ items:
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
                 category: apihub-organization-apis
-                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-apigee-apihub-demo-proxy-fauna-crocodiles
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-xqxklnlxqea7vxvt7tahs6wgsoouw4lo
                 uri: ""
         - kind: ReferenceList
           metadata:

--- a/runtime/dolphins/info.yaml
+++ b/runtime/dolphins/info.yaml
@@ -3,7 +3,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-proxy-fauna-dolphins
+      name: generate-animal-apis-32rrlf63wpt45ci4iimmkpk22rk33dk6
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
@@ -41,7 +41,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-product-fauna-dolphins
+      name: generate-animal-apis-74ntzkqfm2rm4owhh5yumatzbizgr54y
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
@@ -69,7 +69,7 @@ items:
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
                 category: apihub-organization-apis
-                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-apigee-apihub-demo-proxy-fauna-dolphins
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-32rrlf63wpt45ci4iimmkpk22rk33dk6
                 uri: ""
         - kind: ReferenceList
           metadata:

--- a/runtime/elephants/info.yaml
+++ b/runtime/elephants/info.yaml
@@ -3,7 +3,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-proxy-fauna-elephants
+      name: generate-animal-apis-xyytpwxwfq6bslt3zoqrytogbrqyh4aa
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
@@ -41,7 +41,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-product-fauna-elephants
+      name: generate-animal-apis-jocxgs2q2bnrzbv4s7ratcj4j2ec5h5u
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
@@ -69,7 +69,7 @@ items:
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
                 category: apihub-organization-apis
-                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-apigee-apihub-demo-proxy-fauna-elephants
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-xyytpwxwfq6bslt3zoqrytogbrqyh4aa
                 uri: ""
         - kind: ReferenceList
           metadata:

--- a/runtime/flamingos/info.yaml
+++ b/runtime/flamingos/info.yaml
@@ -3,7 +3,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-proxy-fauna-flamingos
+      name: generate-animal-apis-tmzxc4eqmhhfs7bdx7kcwxnr65bbh2wj
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
@@ -41,7 +41,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-product-fauna-flamingos
+      name: generate-animal-apis-4psvzhlxrxbv64ubmmzb3flgxbzyhc57
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
@@ -69,7 +69,7 @@ items:
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
                 category: apihub-organization-apis
-                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-apigee-apihub-demo-proxy-fauna-flamingos
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-tmzxc4eqmhhfs7bdx7kcwxnr65bbh2wj
                 uri: ""
         - kind: ReferenceList
           metadata:

--- a/runtime/giraffes/info.yaml
+++ b/runtime/giraffes/info.yaml
@@ -3,7 +3,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-proxy-fauna-giraffes
+      name: generate-animal-apis-ksonaqi3oincuf2mnsis7qbagvsso42m
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
@@ -41,7 +41,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-product-fauna-giraffes
+      name: generate-animal-apis-fgceqy5a4d26i6rb7dsp52wd2m6xjejv
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
@@ -69,7 +69,7 @@ items:
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
                 category: apihub-organization-apis
-                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-apigee-apihub-demo-proxy-fauna-giraffes
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-ksonaqi3oincuf2mnsis7qbagvsso42m
                 uri: ""
         - kind: ReferenceList
           metadata:

--- a/runtime/hedgehogs/info.yaml
+++ b/runtime/hedgehogs/info.yaml
@@ -3,7 +3,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-proxy-fauna-hedgehogs
+      name: generate-animal-apis-eah6eqfecoz53rh6slxsgmzpqqhmdpnd
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
@@ -41,7 +41,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-product-fauna-hedgehogs
+      name: generate-animal-apis-verbhsr3d2llb5npaeccrgavs6n3rjxw
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
@@ -69,7 +69,7 @@ items:
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
                 category: apihub-organization-apis
-                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-apigee-apihub-demo-proxy-fauna-hedgehogs
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-eah6eqfecoz53rh6slxsgmzpqqhmdpnd
                 uri: ""
         - kind: ReferenceList
           metadata:

--- a/runtime/iguanas/info.yaml
+++ b/runtime/iguanas/info.yaml
@@ -3,7 +3,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-proxy-fauna-iguanas
+      name: generate-animal-apis-tffcfostdipjs4muibmrv4rzcvzsapph
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
@@ -41,7 +41,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-product-fauna-iguanas
+      name: generate-animal-apis-6kwzosiiyozsf5bce23ggyv7los4vzuw
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
@@ -69,7 +69,7 @@ items:
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
                 category: apihub-organization-apis
-                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-apigee-apihub-demo-proxy-fauna-iguanas
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-tffcfostdipjs4muibmrv4rzcvzsapph
                 uri: ""
         - kind: ReferenceList
           metadata:

--- a/runtime/jaguars/info.yaml
+++ b/runtime/jaguars/info.yaml
@@ -3,7 +3,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-proxy-fauna-jaguars
+      name: generate-animal-apis-kfaghart3xehanaf57kgw2dm3k4fh7j7
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
@@ -41,7 +41,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-product-fauna-jaguars
+      name: generate-animal-apis-lkc47rqrrphmydgpwlrh3uhemjfmobch
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
@@ -69,7 +69,7 @@ items:
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
                 category: apihub-organization-apis
-                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-apigee-apihub-demo-proxy-fauna-jaguars
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-kfaghart3xehanaf57kgw2dm3k4fh7j7
                 uri: ""
         - kind: ReferenceList
           metadata:

--- a/runtime/kangaroos/info.yaml
+++ b/runtime/kangaroos/info.yaml
@@ -3,7 +3,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-proxy-fauna-kangaroos
+      name: generate-animal-apis-v572ftq25ohhgwibelgriroaslcql7ys
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
@@ -41,7 +41,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-product-fauna-kangaroos
+      name: generate-animal-apis-lxniwsmfhdfrnopo74ucck3oy4u7cttd
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
@@ -69,7 +69,7 @@ items:
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
                 category: apihub-organization-apis
-                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-apigee-apihub-demo-proxy-fauna-kangaroos
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-v572ftq25ohhgwibelgriroaslcql7ys
                 uri: ""
         - kind: ReferenceList
           metadata:

--- a/runtime/lemurs/info.yaml
+++ b/runtime/lemurs/info.yaml
@@ -3,7 +3,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-proxy-fauna-lemurs
+      name: generate-animal-apis-67b4fq7hbanxrevgdtafmbjsc3ixi46p
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
@@ -41,7 +41,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-product-fauna-lemurs
+      name: generate-animal-apis-zc4bt6zdjikszv6ichqubbnfyifzmkzj
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
@@ -69,7 +69,7 @@ items:
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
                 category: apihub-organization-apis
-                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-apigee-apihub-demo-proxy-fauna-lemurs
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-67b4fq7hbanxrevgdtafmbjsc3ixi46p
                 uri: ""
         - kind: ReferenceList
           metadata:

--- a/runtime/monkeys/info.yaml
+++ b/runtime/monkeys/info.yaml
@@ -3,7 +3,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-proxy-fauna-monkeys
+      name: generate-animal-apis-2h5lmfcyxkhnqj3eaiiwid3gyp6gs75n
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
@@ -41,7 +41,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-product-fauna-monkeys
+      name: generate-animal-apis-jiiedzpzupsixri6crgkmpehrgsx5zhy
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
@@ -69,7 +69,7 @@ items:
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
                 category: apihub-organization-apis
-                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-apigee-apihub-demo-proxy-fauna-monkeys
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-2h5lmfcyxkhnqj3eaiiwid3gyp6gs75n
                 uri: ""
         - kind: ReferenceList
           metadata:

--- a/runtime/nightingales/info.yaml
+++ b/runtime/nightingales/info.yaml
@@ -3,7 +3,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-proxy-fauna-nightingales
+      name: generate-animal-apis-4t67owiqj76ijdva736s6uodsefieuly
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
@@ -41,7 +41,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-product-fauna-nightingales
+      name: generate-animal-apis-ug4mkjzuucequkibt7ycu5as2jwmxml7
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
@@ -69,7 +69,7 @@ items:
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
                 category: apihub-organization-apis
-                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-apigee-apihub-demo-proxy-fauna-nightingales
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-4t67owiqj76ijdva736s6uodsefieuly
                 uri: ""
         - kind: ReferenceList
           metadata:

--- a/runtime/ostriches/info.yaml
+++ b/runtime/ostriches/info.yaml
@@ -3,7 +3,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-proxy-fauna-ostriches
+      name: generate-animal-apis-py424mivw2biwyvf3n4rhkawf6tmncwa
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
@@ -41,7 +41,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-product-fauna-ostriches
+      name: generate-animal-apis-mmw3tvbto4va24yrkdcfyhkge2icb7od
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
@@ -69,7 +69,7 @@ items:
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
                 category: apihub-organization-apis
-                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-apigee-apihub-demo-proxy-fauna-ostriches
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-py424mivw2biwyvf3n4rhkawf6tmncwa
                 uri: ""
         - kind: ReferenceList
           metadata:

--- a/runtime/porcupines/info.yaml
+++ b/runtime/porcupines/info.yaml
@@ -3,7 +3,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-proxy-fauna-porcupines
+      name: generate-animal-apis-4tmq457kfloyaeb65ka4rzzkrpmrokxa
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
@@ -41,7 +41,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-product-fauna-porcupines
+      name: generate-animal-apis-r7wosnc4oye6bbj6f7islpj33q76cul3
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
@@ -69,7 +69,7 @@ items:
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
                 category: apihub-organization-apis
-                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-apigee-apihub-demo-proxy-fauna-porcupines
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-4tmq457kfloyaeb65ka4rzzkrpmrokxa
                 uri: ""
         - kind: ReferenceList
           metadata:

--- a/runtime/quokkas/info.yaml
+++ b/runtime/quokkas/info.yaml
@@ -3,7 +3,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-proxy-fauna-quokkas
+      name: generate-animal-apis-h76ptgcunz5hj6kmcp6obkqtnjfeoo6o
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
@@ -41,7 +41,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-product-fauna-quokkas
+      name: generate-animal-apis-6wzxcyeyglihkwesjlkkgweifupg4jay
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
@@ -69,7 +69,7 @@ items:
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
                 category: apihub-organization-apis
-                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-apigee-apihub-demo-proxy-fauna-quokkas
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-h76ptgcunz5hj6kmcp6obkqtnjfeoo6o
                 uri: ""
         - kind: ReferenceList
           metadata:

--- a/runtime/raccoons/info.yaml
+++ b/runtime/raccoons/info.yaml
@@ -3,7 +3,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-proxy-fauna-raccoons
+      name: generate-animal-apis-a6dzq53bhwi7xbbxt4im3yyylrftlsnk
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
@@ -41,7 +41,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-product-fauna-raccoons
+      name: generate-animal-apis-sng6jt6ixad53egzju4kwjwipjd2zoe6
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
@@ -69,7 +69,7 @@ items:
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
                 category: apihub-organization-apis
-                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-apigee-apihub-demo-proxy-fauna-raccoons
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-a6dzq53bhwi7xbbxt4im3yyylrftlsnk
                 uri: ""
         - kind: ReferenceList
           metadata:

--- a/runtime/salamanders/info.yaml
+++ b/runtime/salamanders/info.yaml
@@ -3,7 +3,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-proxy-fauna-salamanders
+      name: generate-animal-apis-fd7qlg2zugrin3iuk7t2ynybzcej6an4
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
@@ -41,7 +41,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-product-fauna-salamanders
+      name: generate-animal-apis-l4jlui3gzi2umx27gbd6qfya3hkeovri
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
@@ -69,7 +69,7 @@ items:
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
                 category: apihub-organization-apis
-                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-apigee-apihub-demo-proxy-fauna-salamanders
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-fd7qlg2zugrin3iuk7t2ynybzcej6an4
                 uri: ""
         - kind: ReferenceList
           metadata:

--- a/runtime/tortoises/info.yaml
+++ b/runtime/tortoises/info.yaml
@@ -3,7 +3,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-proxy-fauna-tortoises
+      name: generate-animal-apis-vwmvyhthleh4dz2wak4yfo3754o22u7g
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
@@ -41,7 +41,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-product-fauna-tortoises
+      name: generate-animal-apis-r2r6mjf5hwsfcowi3jv7wzxtil4wrqk7
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
@@ -69,7 +69,7 @@ items:
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
                 category: apihub-organization-apis
-                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-apigee-apihub-demo-proxy-fauna-tortoises
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-vwmvyhthleh4dz2wak4yfo3754o22u7g
                 uri: ""
         - kind: ReferenceList
           metadata:

--- a/runtime/uakaris/info.yaml
+++ b/runtime/uakaris/info.yaml
@@ -3,7 +3,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-proxy-fauna-uakaris
+      name: generate-animal-apis-ynbahv4jwfxjy5svkrnf7tpqao3pcqjo
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
@@ -41,7 +41,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-product-fauna-uakaris
+      name: generate-animal-apis-d7ldoky4riza3aeff2nnjxgi3ecgm7ux
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
@@ -69,7 +69,7 @@ items:
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
                 category: apihub-organization-apis
-                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-apigee-apihub-demo-proxy-fauna-uakaris
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-ynbahv4jwfxjy5svkrnf7tpqao3pcqjo
                 uri: ""
         - kind: ReferenceList
           metadata:

--- a/runtime/vultures/info.yaml
+++ b/runtime/vultures/info.yaml
@@ -3,7 +3,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-proxy-fauna-vultures
+      name: generate-animal-apis-nquasooumwze5rokykwvn5ez4pxthrqr
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
@@ -41,7 +41,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-product-fauna-vultures
+      name: generate-animal-apis-eeqkmnigsfvu5fyspeie2ltxcj3qxy5s
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
@@ -69,7 +69,7 @@ items:
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
                 category: apihub-organization-apis
-                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-apigee-apihub-demo-proxy-fauna-vultures
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-nquasooumwze5rokykwvn5ez4pxthrqr
                 uri: ""
         - kind: ReferenceList
           metadata:

--- a/runtime/whales/info.yaml
+++ b/runtime/whales/info.yaml
@@ -3,7 +3,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-proxy-fauna-whales
+      name: generate-animal-apis-meympzg77jgctttyelpmw2drvivwnh32
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
@@ -41,7 +41,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-product-fauna-whales
+      name: generate-animal-apis-qd67qg2r5rb26dpl6so6oqxzmrrpuls3
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
@@ -69,7 +69,7 @@ items:
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
                 category: apihub-organization-apis
-                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-apigee-apihub-demo-proxy-fauna-whales
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-meympzg77jgctttyelpmw2drvivwnh32
                 uri: ""
         - kind: ReferenceList
           metadata:

--- a/runtime/xeruses/info.yaml
+++ b/runtime/xeruses/info.yaml
@@ -3,7 +3,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-proxy-fauna-xeruses
+      name: generate-animal-apis-by2ldivjoz3ph4sodohvvswbodiqfipf
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
@@ -41,7 +41,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-product-fauna-xeruses
+      name: generate-animal-apis-dzbf5iqnsa5pmybpzhvyd354dqygra2h
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
@@ -69,7 +69,7 @@ items:
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
                 category: apihub-organization-apis
-                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-apigee-apihub-demo-proxy-fauna-xeruses
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-by2ldivjoz3ph4sodohvvswbodiqfipf
                 uri: ""
         - kind: ReferenceList
           metadata:

--- a/runtime/yaks/info.yaml
+++ b/runtime/yaks/info.yaml
@@ -3,7 +3,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-proxy-fauna-yaks
+      name: generate-animal-apis-uaw2dsgdsmajo42kl6b3c2oncdxqydd4
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
@@ -41,7 +41,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-product-fauna-yaks
+      name: generate-animal-apis-wj6xirle4so5yan2uz2em3otif24vh2a
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
@@ -69,7 +69,7 @@ items:
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
                 category: apihub-organization-apis
-                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-apigee-apihub-demo-proxy-fauna-yaks
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-uaw2dsgdsmajo42kl6b3c2oncdxqydd4
                 uri: ""
         - kind: ReferenceList
           metadata:

--- a/runtime/zebras/info.yaml
+++ b/runtime/zebras/info.yaml
@@ -3,7 +3,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-proxy-fauna-zebras
+      name: generate-animal-apis-5ezykm5hj5rstnhjdyn5m4usc4u6donf
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
@@ -41,7 +41,7 @@ items:
   - apiVersion: apigeeregistry/v1
     kind: API
     metadata:
-      name: generate-animal-apis-apigee-apihub-demo-product-fauna-zebras
+      name: generate-animal-apis-2p6xarpy5pgnoxtv7siv33ks5pyq2fkw
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
@@ -69,7 +69,7 @@ items:
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
                 category: apihub-organization-apis
-                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-apigee-apihub-demo-proxy-fauna-zebras
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-5ezykm5hj5rstnhjdyn5m4usc4u6donf
                 uri: ""
         - kind: ReferenceList
           metadata:

--- a/traffic/000000/info.yaml
+++ b/traffic/000000/info.yaml
@@ -1,7 +1,7 @@
 apiVersion: apigeeregistry/v1
 kind: API
 metadata:
-  name: generate-animal-apis-apigee-apihub-demo-traffic-000000
+  name: generate-animal-apis-67vfdqxjo4m3iq24obwm5usv4yz624kq
   labels:
     apihub-kind: traffic
     apihub-source: generate-animal-apis

--- a/traffic/000001/info.yaml
+++ b/traffic/000001/info.yaml
@@ -1,7 +1,7 @@
 apiVersion: apigeeregistry/v1
 kind: API
 metadata:
-  name: generate-animal-apis-apigee-apihub-demo-traffic-000001
+  name: generate-animal-apis-v7l3npfi4rukklpr7uiplhuqxiio7q6k
   labels:
     apihub-kind: traffic
     apihub-source: generate-animal-apis

--- a/traffic/000002/info.yaml
+++ b/traffic/000002/info.yaml
@@ -1,7 +1,7 @@
 apiVersion: apigeeregistry/v1
 kind: API
 metadata:
-  name: generate-animal-apis-apigee-apihub-demo-traffic-000002
+  name: generate-animal-apis-nc6axd7wrcn4hyvr3ucvmaaubfbr5wb4
   labels:
     apihub-kind: traffic
     apihub-source: generate-animal-apis

--- a/traffic/000003/info.yaml
+++ b/traffic/000003/info.yaml
@@ -1,7 +1,7 @@
 apiVersion: apigeeregistry/v1
 kind: API
 metadata:
-  name: generate-animal-apis-apigee-apihub-demo-traffic-000003
+  name: generate-animal-apis-q2pzvjnwwjrqu6kuxwjdsref2q4cb753
   labels:
     apihub-kind: traffic
     apihub-source: generate-animal-apis

--- a/traffic/000004/info.yaml
+++ b/traffic/000004/info.yaml
@@ -1,7 +1,7 @@
 apiVersion: apigeeregistry/v1
 kind: API
 metadata:
-  name: generate-animal-apis-apigee-apihub-demo-traffic-000004
+  name: generate-animal-apis-3z6l6khjozuabub64dnliruxixgb4tew
   labels:
     apihub-kind: traffic
     apihub-source: generate-animal-apis

--- a/traffic/000005/info.yaml
+++ b/traffic/000005/info.yaml
@@ -1,7 +1,7 @@
 apiVersion: apigeeregistry/v1
 kind: API
 metadata:
-  name: generate-animal-apis-apigee-apihub-demo-traffic-000005
+  name: generate-animal-apis-ezyxkpbc7kbmpxdek44jsebarhakim72
   labels:
     apihub-kind: traffic
     apihub-source: generate-animal-apis

--- a/traffic/000006/info.yaml
+++ b/traffic/000006/info.yaml
@@ -1,7 +1,7 @@
 apiVersion: apigeeregistry/v1
 kind: API
 metadata:
-  name: generate-animal-apis-apigee-apihub-demo-traffic-000006
+  name: generate-animal-apis-4xpvle44z7c46ktqo2zidqdfnjr64fe2
   labels:
     apihub-kind: traffic
     apihub-source: generate-animal-apis

--- a/traffic/000007/info.yaml
+++ b/traffic/000007/info.yaml
@@ -1,7 +1,7 @@
 apiVersion: apigeeregistry/v1
 kind: API
 metadata:
-  name: generate-animal-apis-apigee-apihub-demo-traffic-000007
+  name: generate-animal-apis-aocey2476dwc5pjgehdhc2hxus3wd3sn
   labels:
     apihub-kind: traffic
     apihub-source: generate-animal-apis

--- a/traffic/000008/info.yaml
+++ b/traffic/000008/info.yaml
@@ -1,7 +1,7 @@
 apiVersion: apigeeregistry/v1
 kind: API
 metadata:
-  name: generate-animal-apis-apigee-apihub-demo-traffic-000008
+  name: generate-animal-apis-kgxkjw34xa57hhj234urvdghvby4hj2r
   labels:
     apihub-kind: traffic
     apihub-source: generate-animal-apis

--- a/traffic/000009/info.yaml
+++ b/traffic/000009/info.yaml
@@ -1,7 +1,7 @@
 apiVersion: apigeeregistry/v1
 kind: API
 metadata:
-  name: generate-animal-apis-apigee-apihub-demo-traffic-000009
+  name: generate-animal-apis-c7zo43dlhltugncm5acplwo2ukkla7rj
   labels:
     apihub-kind: traffic
     apihub-source: generate-animal-apis

--- a/traffic/000010/info.yaml
+++ b/traffic/000010/info.yaml
@@ -1,7 +1,7 @@
 apiVersion: apigeeregistry/v1
 kind: API
 metadata:
-  name: generate-animal-apis-apigee-apihub-demo-traffic-000010
+  name: generate-animal-apis-rziiyurowlq4n4akwoaiws2unb3ygwc3
   labels:
     apihub-kind: traffic
     apihub-source: generate-animal-apis

--- a/traffic/000011/info.yaml
+++ b/traffic/000011/info.yaml
@@ -1,7 +1,7 @@
 apiVersion: apigeeregistry/v1
 kind: API
 metadata:
-  name: generate-animal-apis-apigee-apihub-demo-traffic-000011
+  name: generate-animal-apis-mnflmjrmplapzjyxd6dwepmnirorsx7i
   labels:
     apihub-kind: traffic
     apihub-source: generate-animal-apis

--- a/traffic/000012/info.yaml
+++ b/traffic/000012/info.yaml
@@ -1,7 +1,7 @@
 apiVersion: apigeeregistry/v1
 kind: API
 metadata:
-  name: generate-animal-apis-apigee-apihub-demo-traffic-000012
+  name: generate-animal-apis-o7xiwbs63mkuj6fekwg3qhtz7x3ngaa5
   labels:
     apihub-kind: traffic
     apihub-source: generate-animal-apis

--- a/traffic/000013/info.yaml
+++ b/traffic/000013/info.yaml
@@ -1,7 +1,7 @@
 apiVersion: apigeeregistry/v1
 kind: API
 metadata:
-  name: generate-animal-apis-apigee-apihub-demo-traffic-000013
+  name: generate-animal-apis-6t4govat3ni6dm6x27y3nedepmeetp36
   labels:
     apihub-kind: traffic
     apihub-source: generate-animal-apis

--- a/traffic/000014/info.yaml
+++ b/traffic/000014/info.yaml
@@ -1,7 +1,7 @@
 apiVersion: apigeeregistry/v1
 kind: API
 metadata:
-  name: generate-animal-apis-apigee-apihub-demo-traffic-000014
+  name: generate-animal-apis-mhigjlduskzrlsfvlrn2uczpotqkelrj
   labels:
     apihub-kind: traffic
     apihub-source: generate-animal-apis

--- a/traffic/000015/info.yaml
+++ b/traffic/000015/info.yaml
@@ -1,7 +1,7 @@
 apiVersion: apigeeregistry/v1
 kind: API
 metadata:
-  name: generate-animal-apis-apigee-apihub-demo-traffic-000015
+  name: generate-animal-apis-mmfcx3x267dwvk3ytuuh5rd6aenu3ahe
   labels:
     apihub-kind: traffic
     apihub-source: generate-animal-apis

--- a/traffic/000016/info.yaml
+++ b/traffic/000016/info.yaml
@@ -1,7 +1,7 @@
 apiVersion: apigeeregistry/v1
 kind: API
 metadata:
-  name: generate-animal-apis-apigee-apihub-demo-traffic-000016
+  name: generate-animal-apis-kqgvbytugv2qlpwqzxybuz7uspbfvyee
   labels:
     apihub-kind: traffic
     apihub-source: generate-animal-apis

--- a/traffic/000017/info.yaml
+++ b/traffic/000017/info.yaml
@@ -1,7 +1,7 @@
 apiVersion: apigeeregistry/v1
 kind: API
 metadata:
-  name: generate-animal-apis-apigee-apihub-demo-traffic-000017
+  name: generate-animal-apis-rkoqazzuyjxbockg57duyrjpjo4unutx
   labels:
     apihub-kind: traffic
     apihub-source: generate-animal-apis

--- a/traffic/000018/info.yaml
+++ b/traffic/000018/info.yaml
@@ -1,7 +1,7 @@
 apiVersion: apigeeregistry/v1
 kind: API
 metadata:
-  name: generate-animal-apis-apigee-apihub-demo-traffic-000018
+  name: generate-animal-apis-axj2wd3gsm2holwoz2qjdivjthwgppri
   labels:
     apihub-kind: traffic
     apihub-source: generate-animal-apis

--- a/traffic/000019/info.yaml
+++ b/traffic/000019/info.yaml
@@ -1,7 +1,7 @@
 apiVersion: apigeeregistry/v1
 kind: API
 metadata:
-  name: generate-animal-apis-apigee-apihub-demo-traffic-000019
+  name: generate-animal-apis-fntt5xwrjvij3f6xxmwa77gnlvfmwo6k
   labels:
     apihub-kind: traffic
     apihub-source: generate-animal-apis

--- a/traffic/000020/info.yaml
+++ b/traffic/000020/info.yaml
@@ -1,7 +1,7 @@
 apiVersion: apigeeregistry/v1
 kind: API
 metadata:
-  name: generate-animal-apis-apigee-apihub-demo-traffic-000020
+  name: generate-animal-apis-ml7pxbo4h2t6cou3yr7navtvife245qr
   labels:
     apihub-kind: traffic
     apihub-source: generate-animal-apis

--- a/traffic/000021/info.yaml
+++ b/traffic/000021/info.yaml
@@ -1,7 +1,7 @@
 apiVersion: apigeeregistry/v1
 kind: API
 metadata:
-  name: generate-animal-apis-apigee-apihub-demo-traffic-000021
+  name: generate-animal-apis-gzlg73t7aqp3pdahhsmyl44gmfqyxyp6
   labels:
     apihub-kind: traffic
     apihub-source: generate-animal-apis

--- a/traffic/000022/info.yaml
+++ b/traffic/000022/info.yaml
@@ -1,7 +1,7 @@
 apiVersion: apigeeregistry/v1
 kind: API
 metadata:
-  name: generate-animal-apis-apigee-apihub-demo-traffic-000022
+  name: generate-animal-apis-wbgqsn2fauctp3aedkn4pakrl3nbno66
   labels:
     apihub-kind: traffic
     apihub-source: generate-animal-apis

--- a/traffic/000023/info.yaml
+++ b/traffic/000023/info.yaml
@@ -1,7 +1,7 @@
 apiVersion: apigeeregistry/v1
 kind: API
 metadata:
-  name: generate-animal-apis-apigee-apihub-demo-traffic-000023
+  name: generate-animal-apis-vsrgryxjobmpctlgoumn7yccigh4hmgq
   labels:
     apihub-kind: traffic
     apihub-source: generate-animal-apis

--- a/traffic/000024/info.yaml
+++ b/traffic/000024/info.yaml
@@ -1,7 +1,7 @@
 apiVersion: apigeeregistry/v1
 kind: API
 metadata:
-  name: generate-animal-apis-apigee-apihub-demo-traffic-000024
+  name: generate-animal-apis-inckqsxnrwmaybjbgw6fq6fknotst5om
   labels:
     apihub-kind: traffic
     apihub-source: generate-animal-apis

--- a/traffic/000025/info.yaml
+++ b/traffic/000025/info.yaml
@@ -1,7 +1,7 @@
 apiVersion: apigeeregistry/v1
 kind: API
 metadata:
-  name: generate-animal-apis-apigee-apihub-demo-traffic-000025
+  name: generate-animal-apis-mslnyucoh3vp7dxmogeeprugksyipmtd
   labels:
     apihub-kind: traffic
     apihub-source: generate-animal-apis


### PR DESCRIPTION
This encodes names using base32-encoded hashes to normalize their lengths.

The hashes are 32 characters long, leaving 31 characters for a source-specific prefix. Currently we use `generate-animals-apis-` for that.

Base 32 is preferred over base 64 because we need lower-case ids.

SHA1 is used instead of SHA256 because the results are shorter (160/5 == 32 chars instead of 256/5 == 52 chars).