### PR TITLE
Add details for classification demos

### DIFF
--- a/apis/aardvarks/openapi.yaml
+++ b/apis/aardvarks/openapi.yaml
@@ -2,6 +2,7 @@ openapi: 3.0.0
 info:
   version: 1.0.0
   title: Fauna Aardvarks API
+  description: Manage a collection of aardvarks.
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:

--- a/apis/bandicoots/openapi.yaml
+++ b/apis/bandicoots/openapi.yaml
@@ -2,6 +2,7 @@ openapi: 3.0.0
 info:
   version: 1.0.0
   title: Fauna Bandicoots API
+  description: Manage a collection of bandicoots.
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:

--- a/apis/crocodiles/openapi.yaml
+++ b/apis/crocodiles/openapi.yaml
@@ -2,6 +2,7 @@ openapi: 3.0.0
 info:
   version: 1.0.0
   title: Fauna Crocodiles API
+  description: Manage a collection of crocodiles.
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:

--- a/apis/dolphins/openapi.yaml
+++ b/apis/dolphins/openapi.yaml
@@ -2,6 +2,7 @@ openapi: 3.0.0
 info:
   version: 1.0.0
   title: Fauna Dolphins API
+  description: Manage a collection of dolphins.
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:

--- a/apis/elephants/openapi.yaml
+++ b/apis/elephants/openapi.yaml
@@ -2,6 +2,7 @@ openapi: 3.0.0
 info:
   version: 1.0.0
   title: Fauna Elephants API
+  description: Manage a collection of elephants.
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:

--- a/apis/flamingos/openapi.yaml
+++ b/apis/flamingos/openapi.yaml
@@ -2,6 +2,7 @@ openapi: 3.0.0
 info:
   version: 1.0.0
   title: Fauna Flamingos API
+  description: Manage a collection of flamingos.
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:

--- a/apis/giraffes/openapi.yaml
+++ b/apis/giraffes/openapi.yaml
@@ -2,6 +2,7 @@ openapi: 3.0.0
 info:
   version: 1.0.0
   title: Fauna Giraffes API
+  description: Manage a collection of giraffes.
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:

--- a/apis/hedgehogs/openapi.yaml
+++ b/apis/hedgehogs/openapi.yaml
@@ -2,6 +2,7 @@ openapi: 3.0.0
 info:
   version: 1.0.0
   title: Fauna Hedgehogs API
+  description: Manage a collection of hedgehogs.
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:

--- a/apis/iguanas/openapi.yaml
+++ b/apis/iguanas/openapi.yaml
@@ -2,6 +2,7 @@ openapi: 3.0.0
 info:
   version: 1.0.0
   title: Fauna Iguanas API
+  description: Manage a collection of iguanas.
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:

--- a/apis/jaguars/openapi.yaml
+++ b/apis/jaguars/openapi.yaml
@@ -2,6 +2,7 @@ openapi: 3.0.0
 info:
   version: 1.0.0
   title: Fauna Jaguars API
+  description: Manage a collection of jaguars.
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:

--- a/apis/kangaroos/openapi.yaml
+++ b/apis/kangaroos/openapi.yaml
@@ -2,6 +2,7 @@ openapi: 3.0.0
 info:
   version: 1.0.0
   title: Fauna Kangaroos API
+  description: Manage a collection of kangaroos.
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:

--- a/apis/lemurs/openapi.yaml
+++ b/apis/lemurs/openapi.yaml
@@ -2,6 +2,7 @@ openapi: 3.0.0
 info:
   version: 1.0.0
   title: Fauna Lemurs API
+  description: Manage a collection of lemurs.
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:

--- a/apis/monkeys/openapi.yaml
+++ b/apis/monkeys/openapi.yaml
@@ -2,6 +2,7 @@ openapi: 3.0.0
 info:
   version: 1.0.0
   title: Fauna Monkeys API
+  description: Manage a collection of monkeys.
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:

--- a/apis/nightingales/openapi.yaml
+++ b/apis/nightingales/openapi.yaml
@@ -2,6 +2,7 @@ openapi: 3.0.0
 info:
   version: 1.0.0
   title: Fauna Nightingales API
+  description: Manage a collection of nightingales.
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:

--- a/apis/ostriches/openapi.yaml
+++ b/apis/ostriches/openapi.yaml
@@ -2,6 +2,7 @@ openapi: 3.0.0
 info:
   version: 1.0.0
   title: Fauna Ostriches API
+  description: Manage a collection of ostriches.
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:

--- a/apis/porcupines/openapi.yaml
+++ b/apis/porcupines/openapi.yaml
@@ -2,6 +2,7 @@ openapi: 3.0.0
 info:
   version: 1.0.0
   title: Fauna Porcupines API
+  description: Manage a collection of porcupines.
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:

--- a/apis/quokkas/openapi.yaml
+++ b/apis/quokkas/openapi.yaml
@@ -2,6 +2,7 @@ openapi: 3.0.0
 info:
   version: 1.0.0
   title: Fauna Quokkas API
+  description: Manage a collection of quokkas.
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:

--- a/apis/raccoons/openapi.yaml
+++ b/apis/raccoons/openapi.yaml
@@ -2,6 +2,7 @@ openapi: 3.0.0
 info:
   version: 1.0.0
   title: Fauna Raccoons API
+  description: Manage a collection of raccoons.
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:

--- a/apis/salamanders/openapi.yaml
+++ b/apis/salamanders/openapi.yaml
@@ -2,6 +2,7 @@ openapi: 3.0.0
 info:
   version: 1.0.0
   title: Fauna Salamanders API
+  description: Manage a collection of salamanders.
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:

--- a/apis/tortoises/openapi.yaml
+++ b/apis/tortoises/openapi.yaml
@@ -2,6 +2,7 @@ openapi: 3.0.0
 info:
   version: 1.0.0
   title: Fauna Tortoises API
+  description: Manage a collection of tortoises.
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:

--- a/apis/uakaris/openapi.yaml
+++ b/apis/uakaris/openapi.yaml
@@ -2,6 +2,7 @@ openapi: 3.0.0
 info:
   version: 1.0.0
   title: Fauna Uakaris API
+  description: Manage a collection of uakaris.
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:

--- a/apis/vultures/openapi.yaml
+++ b/apis/vultures/openapi.yaml
@@ -2,6 +2,7 @@ openapi: 3.0.0
 info:
   version: 1.0.0
   title: Fauna Vultures API
+  description: Manage a collection of vultures.
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:

--- a/apis/whales/openapi.yaml
+++ b/apis/whales/openapi.yaml
@@ -2,6 +2,7 @@ openapi: 3.0.0
 info:
   version: 1.0.0
   title: Fauna Whales API
+  description: Manage a collection of whales.
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:

--- a/apis/xeruses/openapi.yaml
+++ b/apis/xeruses/openapi.yaml
@@ -2,6 +2,7 @@ openapi: 3.0.0
 info:
   version: 1.0.0
   title: Fauna Xeruses API
+  description: Manage a collection of xeruses.
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:

--- a/apis/yaks/openapi.yaml
+++ b/apis/yaks/openapi.yaml
@@ -2,6 +2,7 @@ openapi: 3.0.0
 info:
   version: 1.0.0
   title: Fauna Yaks API
+  description: Manage a collection of yaks.
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:

--- a/apis/zebras/openapi.yaml
+++ b/apis/zebras/openapi.yaml
@@ -2,6 +2,7 @@ openapi: 3.0.0
 info:
   version: 1.0.0
   title: Fauna Zebras API
+  description: Manage a collection of zebras.
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:

--- a/cmd/generate-animal-apis/enrolled.go
+++ b/cmd/generate-animal-apis/enrolled.go
@@ -177,8 +177,9 @@ func generateEnrollment(animal *Animal) error {
 	openapi := &OpenAPI{
 		OpenAPI: "3.0.0",
 		Info: &OpenAPIInfo{
-			Version: "1.0.0",
-			Title:   displayName,
+			Version:     "1.0.0",
+			Title:       displayName,
+			Description: fmt.Sprintf("Manage a collection of %s.", lowerPlural),
 		},
 		Servers: []*OpenAPIServer{
 			{

--- a/cmd/generate-animal-apis/openapi.go
+++ b/cmd/generate-animal-apis/openapi.go
@@ -23,8 +23,9 @@ type OpenAPI struct {
 }
 
 type OpenAPIInfo struct {
-	Version string `yaml:"version,omitempty"`
-	Title   string `yaml:"title,omitempty"`
+	Version     string `yaml:"version,omitempty"`
+	Title       string `yaml:"title,omitempty"`
+	Description string `yaml:"description,omitempty"`
 }
 
 type OpenAPIServer struct {

--- a/cmd/generate-animal-apis/runtime.go
+++ b/cmd/generate-animal-apis/runtime.go
@@ -148,13 +148,13 @@ func generateRuntimeMocks(animal *Animal) error {
 			{
 				Id:          enrolledApiID,
 				DisplayName: enrolledApiID,
-				Category:    "apihub-organization-apis",
+				Category:    "enrollment",
 				Resource:    "projects/apigee-apihub-demo/locations/global/apis/" + enrolledApiID,
 			},
 			{
 				Id:          "apigee-apihub-demo-petstore-proxy",
 				DisplayName: "apigee-apihub-demo proxy: petstore",
-				Category:    "apihub-organization-apis",
+				Category:    "proxy",
 				Resource:    "projects/apigee-apihub-demo/locations/global/apis/" + proxyApiID,
 			},
 		},

--- a/cmd/generate-animal-apis/traffic.go
+++ b/cmd/generate-animal-apis/traffic.go
@@ -76,7 +76,7 @@ func generateTraffic(id int, animal *Animal) error {
 			{
 				Id:          enrolledApiID,
 				DisplayName: "Enrolled API",
-				Category:    "apihub-organization-apis",
+				Category:    "enrollment",
 				Resource:    "projects/apigee-apihub-demo/locations/global/apis/" + enrolledApiID,
 			},
 		},

--- a/runtime/aardvarks/info.yaml
+++ b/runtime/aardvarks/info.yaml
@@ -64,12 +64,12 @@ items:
             references:
               - id: fauna-aardvarks
                 displayName: fauna-aardvarks
-                category: apihub-organization-apis
+                category: enrollment
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-aardvarks
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: apihub-organization-apis
+                category: proxy
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-ytikblczmnmc5wfn7wx2a62v2k677cqr
                 uri: ""
         - kind: ReferenceList

--- a/runtime/bandicoots/info.yaml
+++ b/runtime/bandicoots/info.yaml
@@ -64,12 +64,12 @@ items:
             references:
               - id: fauna-bandicoots
                 displayName: fauna-bandicoots
-                category: apihub-organization-apis
+                category: enrollment
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-bandicoots
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: apihub-organization-apis
+                category: proxy
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-4vajvc52av2p4te5llvmbqjjhvgewdw6
                 uri: ""
         - kind: ReferenceList

--- a/runtime/crocodiles/info.yaml
+++ b/runtime/crocodiles/info.yaml
@@ -64,12 +64,12 @@ items:
             references:
               - id: fauna-crocodiles
                 displayName: fauna-crocodiles
-                category: apihub-organization-apis
+                category: enrollment
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-crocodiles
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: apihub-organization-apis
+                category: proxy
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-xqxklnlxqea7vxvt7tahs6wgsoouw4lo
                 uri: ""
         - kind: ReferenceList

--- a/runtime/dolphins/info.yaml
+++ b/runtime/dolphins/info.yaml
@@ -64,12 +64,12 @@ items:
             references:
               - id: fauna-dolphins
                 displayName: fauna-dolphins
-                category: apihub-organization-apis
+                category: enrollment
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-dolphins
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: apihub-organization-apis
+                category: proxy
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-32rrlf63wpt45ci4iimmkpk22rk33dk6
                 uri: ""
         - kind: ReferenceList

--- a/runtime/elephants/info.yaml
+++ b/runtime/elephants/info.yaml
@@ -64,12 +64,12 @@ items:
             references:
               - id: fauna-elephants
                 displayName: fauna-elephants
-                category: apihub-organization-apis
+                category: enrollment
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-elephants
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: apihub-organization-apis
+                category: proxy
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-xyytpwxwfq6bslt3zoqrytogbrqyh4aa
                 uri: ""
         - kind: ReferenceList

--- a/runtime/flamingos/info.yaml
+++ b/runtime/flamingos/info.yaml
@@ -64,12 +64,12 @@ items:
             references:
               - id: fauna-flamingos
                 displayName: fauna-flamingos
-                category: apihub-organization-apis
+                category: enrollment
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-flamingos
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: apihub-organization-apis
+                category: proxy
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-tmzxc4eqmhhfs7bdx7kcwxnr65bbh2wj
                 uri: ""
         - kind: ReferenceList

--- a/runtime/giraffes/info.yaml
+++ b/runtime/giraffes/info.yaml
@@ -64,12 +64,12 @@ items:
             references:
               - id: fauna-giraffes
                 displayName: fauna-giraffes
-                category: apihub-organization-apis
+                category: enrollment
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-giraffes
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: apihub-organization-apis
+                category: proxy
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-ksonaqi3oincuf2mnsis7qbagvsso42m
                 uri: ""
         - kind: ReferenceList

--- a/runtime/hedgehogs/info.yaml
+++ b/runtime/hedgehogs/info.yaml
@@ -64,12 +64,12 @@ items:
             references:
               - id: fauna-hedgehogs
                 displayName: fauna-hedgehogs
-                category: apihub-organization-apis
+                category: enrollment
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-hedgehogs
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: apihub-organization-apis
+                category: proxy
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-eah6eqfecoz53rh6slxsgmzpqqhmdpnd
                 uri: ""
         - kind: ReferenceList

--- a/runtime/iguanas/info.yaml
+++ b/runtime/iguanas/info.yaml
@@ -64,12 +64,12 @@ items:
             references:
               - id: fauna-iguanas
                 displayName: fauna-iguanas
-                category: apihub-organization-apis
+                category: enrollment
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-iguanas
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: apihub-organization-apis
+                category: proxy
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-tffcfostdipjs4muibmrv4rzcvzsapph
                 uri: ""
         - kind: ReferenceList

--- a/runtime/jaguars/info.yaml
+++ b/runtime/jaguars/info.yaml
@@ -64,12 +64,12 @@ items:
             references:
               - id: fauna-jaguars
                 displayName: fauna-jaguars
-                category: apihub-organization-apis
+                category: enrollment
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-jaguars
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: apihub-organization-apis
+                category: proxy
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-kfaghart3xehanaf57kgw2dm3k4fh7j7
                 uri: ""
         - kind: ReferenceList

--- a/runtime/kangaroos/info.yaml
+++ b/runtime/kangaroos/info.yaml
@@ -64,12 +64,12 @@ items:
             references:
               - id: fauna-kangaroos
                 displayName: fauna-kangaroos
-                category: apihub-organization-apis
+                category: enrollment
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-kangaroos
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: apihub-organization-apis
+                category: proxy
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-v572ftq25ohhgwibelgriroaslcql7ys
                 uri: ""
         - kind: ReferenceList

--- a/runtime/lemurs/info.yaml
+++ b/runtime/lemurs/info.yaml
@@ -64,12 +64,12 @@ items:
             references:
               - id: fauna-lemurs
                 displayName: fauna-lemurs
-                category: apihub-organization-apis
+                category: enrollment
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-lemurs
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: apihub-organization-apis
+                category: proxy
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-67b4fq7hbanxrevgdtafmbjsc3ixi46p
                 uri: ""
         - kind: ReferenceList

--- a/runtime/monkeys/info.yaml
+++ b/runtime/monkeys/info.yaml
@@ -64,12 +64,12 @@ items:
             references:
               - id: fauna-monkeys
                 displayName: fauna-monkeys
-                category: apihub-organization-apis
+                category: enrollment
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-monkeys
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: apihub-organization-apis
+                category: proxy
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-2h5lmfcyxkhnqj3eaiiwid3gyp6gs75n
                 uri: ""
         - kind: ReferenceList

--- a/runtime/nightingales/info.yaml
+++ b/runtime/nightingales/info.yaml
@@ -64,12 +64,12 @@ items:
             references:
               - id: fauna-nightingales
                 displayName: fauna-nightingales
-                category: apihub-organization-apis
+                category: enrollment
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-nightingales
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: apihub-organization-apis
+                category: proxy
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-4t67owiqj76ijdva736s6uodsefieuly
                 uri: ""
         - kind: ReferenceList

--- a/runtime/ostriches/info.yaml
+++ b/runtime/ostriches/info.yaml
@@ -64,12 +64,12 @@ items:
             references:
               - id: fauna-ostriches
                 displayName: fauna-ostriches
-                category: apihub-organization-apis
+                category: enrollment
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-ostriches
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: apihub-organization-apis
+                category: proxy
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-py424mivw2biwyvf3n4rhkawf6tmncwa
                 uri: ""
         - kind: ReferenceList

--- a/runtime/porcupines/info.yaml
+++ b/runtime/porcupines/info.yaml
@@ -64,12 +64,12 @@ items:
             references:
               - id: fauna-porcupines
                 displayName: fauna-porcupines
-                category: apihub-organization-apis
+                category: enrollment
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-porcupines
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: apihub-organization-apis
+                category: proxy
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-4tmq457kfloyaeb65ka4rzzkrpmrokxa
                 uri: ""
         - kind: ReferenceList

--- a/runtime/quokkas/info.yaml
+++ b/runtime/quokkas/info.yaml
@@ -64,12 +64,12 @@ items:
             references:
               - id: fauna-quokkas
                 displayName: fauna-quokkas
-                category: apihub-organization-apis
+                category: enrollment
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-quokkas
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: apihub-organization-apis
+                category: proxy
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-h76ptgcunz5hj6kmcp6obkqtnjfeoo6o
                 uri: ""
         - kind: ReferenceList

--- a/runtime/raccoons/info.yaml
+++ b/runtime/raccoons/info.yaml
@@ -64,12 +64,12 @@ items:
             references:
               - id: fauna-raccoons
                 displayName: fauna-raccoons
-                category: apihub-organization-apis
+                category: enrollment
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-raccoons
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: apihub-organization-apis
+                category: proxy
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-a6dzq53bhwi7xbbxt4im3yyylrftlsnk
                 uri: ""
         - kind: ReferenceList

--- a/runtime/salamanders/info.yaml
+++ b/runtime/salamanders/info.yaml
@@ -64,12 +64,12 @@ items:
             references:
               - id: fauna-salamanders
                 displayName: fauna-salamanders
-                category: apihub-organization-apis
+                category: enrollment
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-salamanders
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: apihub-organization-apis
+                category: proxy
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-fd7qlg2zugrin3iuk7t2ynybzcej6an4
                 uri: ""
         - kind: ReferenceList

--- a/runtime/tortoises/info.yaml
+++ b/runtime/tortoises/info.yaml
@@ -64,12 +64,12 @@ items:
             references:
               - id: fauna-tortoises
                 displayName: fauna-tortoises
-                category: apihub-organization-apis
+                category: enrollment
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-tortoises
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: apihub-organization-apis
+                category: proxy
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-vwmvyhthleh4dz2wak4yfo3754o22u7g
                 uri: ""
         - kind: ReferenceList

--- a/runtime/uakaris/info.yaml
+++ b/runtime/uakaris/info.yaml
@@ -64,12 +64,12 @@ items:
             references:
               - id: fauna-uakaris
                 displayName: fauna-uakaris
-                category: apihub-organization-apis
+                category: enrollment
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-uakaris
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: apihub-organization-apis
+                category: proxy
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-ynbahv4jwfxjy5svkrnf7tpqao3pcqjo
                 uri: ""
         - kind: ReferenceList

--- a/runtime/vultures/info.yaml
+++ b/runtime/vultures/info.yaml
@@ -64,12 +64,12 @@ items:
             references:
               - id: fauna-vultures
                 displayName: fauna-vultures
-                category: apihub-organization-apis
+                category: enrollment
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-vultures
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: apihub-organization-apis
+                category: proxy
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-nquasooumwze5rokykwvn5ez4pxthrqr
                 uri: ""
         - kind: ReferenceList

--- a/runtime/whales/info.yaml
+++ b/runtime/whales/info.yaml
@@ -64,12 +64,12 @@ items:
             references:
               - id: fauna-whales
                 displayName: fauna-whales
-                category: apihub-organization-apis
+                category: enrollment
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-whales
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: apihub-organization-apis
+                category: proxy
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-meympzg77jgctttyelpmw2drvivwnh32
                 uri: ""
         - kind: ReferenceList

--- a/runtime/xeruses/info.yaml
+++ b/runtime/xeruses/info.yaml
@@ -64,12 +64,12 @@ items:
             references:
               - id: fauna-xeruses
                 displayName: fauna-xeruses
-                category: apihub-organization-apis
+                category: enrollment
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-xeruses
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: apihub-organization-apis
+                category: proxy
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-by2ldivjoz3ph4sodohvvswbodiqfipf
                 uri: ""
         - kind: ReferenceList

--- a/runtime/yaks/info.yaml
+++ b/runtime/yaks/info.yaml
@@ -64,12 +64,12 @@ items:
             references:
               - id: fauna-yaks
                 displayName: fauna-yaks
-                category: apihub-organization-apis
+                category: enrollment
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-yaks
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: apihub-organization-apis
+                category: proxy
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-uaw2dsgdsmajo42kl6b3c2oncdxqydd4
                 uri: ""
         - kind: ReferenceList

--- a/runtime/zebras/info.yaml
+++ b/runtime/zebras/info.yaml
@@ -64,12 +64,12 @@ items:
             references:
               - id: fauna-zebras
                 displayName: fauna-zebras
-                category: apihub-organization-apis
+                category: enrollment
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-zebras
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: apihub-organization-apis
+                category: proxy
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-5ezykm5hj5rstnhjdyn5m4usc4u6donf
                 uri: ""
         - kind: ReferenceList

--- a/traffic/000000/info.yaml
+++ b/traffic/000000/info.yaml
@@ -40,6 +40,6 @@ data:
         references:
           - id: fauna-aardvarks
             displayName: Enrolled API
-            category: apihub-organization-apis
+            category: enrollment
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-aardvarks
             uri: ""

--- a/traffic/000001/info.yaml
+++ b/traffic/000001/info.yaml
@@ -40,6 +40,6 @@ data:
         references:
           - id: fauna-bandicoots
             displayName: Enrolled API
-            category: apihub-organization-apis
+            category: enrollment
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-bandicoots
             uri: ""

--- a/traffic/000002/info.yaml
+++ b/traffic/000002/info.yaml
@@ -40,6 +40,6 @@ data:
         references:
           - id: fauna-crocodiles
             displayName: Enrolled API
-            category: apihub-organization-apis
+            category: enrollment
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-crocodiles
             uri: ""

--- a/traffic/000003/info.yaml
+++ b/traffic/000003/info.yaml
@@ -40,6 +40,6 @@ data:
         references:
           - id: fauna-dolphins
             displayName: Enrolled API
-            category: apihub-organization-apis
+            category: enrollment
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-dolphins
             uri: ""

--- a/traffic/000004/info.yaml
+++ b/traffic/000004/info.yaml
@@ -40,6 +40,6 @@ data:
         references:
           - id: fauna-elephants
             displayName: Enrolled API
-            category: apihub-organization-apis
+            category: enrollment
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-elephants
             uri: ""

--- a/traffic/000005/info.yaml
+++ b/traffic/000005/info.yaml
@@ -40,6 +40,6 @@ data:
         references:
           - id: fauna-flamingos
             displayName: Enrolled API
-            category: apihub-organization-apis
+            category: enrollment
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-flamingos
             uri: ""

--- a/traffic/000006/info.yaml
+++ b/traffic/000006/info.yaml
@@ -40,6 +40,6 @@ data:
         references:
           - id: fauna-giraffes
             displayName: Enrolled API
-            category: apihub-organization-apis
+            category: enrollment
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-giraffes
             uri: ""

--- a/traffic/000007/info.yaml
+++ b/traffic/000007/info.yaml
@@ -40,6 +40,6 @@ data:
         references:
           - id: fauna-hedgehogs
             displayName: Enrolled API
-            category: apihub-organization-apis
+            category: enrollment
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-hedgehogs
             uri: ""

--- a/traffic/000008/info.yaml
+++ b/traffic/000008/info.yaml
@@ -40,6 +40,6 @@ data:
         references:
           - id: fauna-iguanas
             displayName: Enrolled API
-            category: apihub-organization-apis
+            category: enrollment
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-iguanas
             uri: ""

--- a/traffic/000009/info.yaml
+++ b/traffic/000009/info.yaml
@@ -40,6 +40,6 @@ data:
         references:
           - id: fauna-jaguars
             displayName: Enrolled API
-            category: apihub-organization-apis
+            category: enrollment
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-jaguars
             uri: ""

--- a/traffic/000010/info.yaml
+++ b/traffic/000010/info.yaml
@@ -40,6 +40,6 @@ data:
         references:
           - id: fauna-kangaroos
             displayName: Enrolled API
-            category: apihub-organization-apis
+            category: enrollment
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-kangaroos
             uri: ""

--- a/traffic/000011/info.yaml
+++ b/traffic/000011/info.yaml
@@ -40,6 +40,6 @@ data:
         references:
           - id: fauna-lemurs
             displayName: Enrolled API
-            category: apihub-organization-apis
+            category: enrollment
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-lemurs
             uri: ""

--- a/traffic/000012/info.yaml
+++ b/traffic/000012/info.yaml
@@ -40,6 +40,6 @@ data:
         references:
           - id: fauna-monkeys
             displayName: Enrolled API
-            category: apihub-organization-apis
+            category: enrollment
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-monkeys
             uri: ""

--- a/traffic/000013/info.yaml
+++ b/traffic/000013/info.yaml
@@ -40,6 +40,6 @@ data:
         references:
           - id: fauna-nightingales
             displayName: Enrolled API
-            category: apihub-organization-apis
+            category: enrollment
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-nightingales
             uri: ""

--- a/traffic/000014/info.yaml
+++ b/traffic/000014/info.yaml
@@ -40,6 +40,6 @@ data:
         references:
           - id: fauna-ostriches
             displayName: Enrolled API
-            category: apihub-organization-apis
+            category: enrollment
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-ostriches
             uri: ""

--- a/traffic/000015/info.yaml
+++ b/traffic/000015/info.yaml
@@ -40,6 +40,6 @@ data:
         references:
           - id: fauna-porcupines
             displayName: Enrolled API
-            category: apihub-organization-apis
+            category: enrollment
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-porcupines
             uri: ""

--- a/traffic/000016/info.yaml
+++ b/traffic/000016/info.yaml
@@ -40,6 +40,6 @@ data:
         references:
           - id: fauna-quokkas
             displayName: Enrolled API
-            category: apihub-organization-apis
+            category: enrollment
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-quokkas
             uri: ""

--- a/traffic/000017/info.yaml
+++ b/traffic/000017/info.yaml
@@ -40,6 +40,6 @@ data:
         references:
           - id: fauna-raccoons
             displayName: Enrolled API
-            category: apihub-organization-apis
+            category: enrollment
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-raccoons
             uri: ""

--- a/traffic/000018/info.yaml
+++ b/traffic/000018/info.yaml
@@ -40,6 +40,6 @@ data:
         references:
           - id: fauna-salamanders
             displayName: Enrolled API
-            category: apihub-organization-apis
+            category: enrollment
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-salamanders
             uri: ""

--- a/traffic/000019/info.yaml
+++ b/traffic/000019/info.yaml
@@ -40,6 +40,6 @@ data:
         references:
           - id: fauna-tortoises
             displayName: Enrolled API
-            category: apihub-organization-apis
+            category: enrollment
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-tortoises
             uri: ""

--- a/traffic/000020/info.yaml
+++ b/traffic/000020/info.yaml
@@ -40,6 +40,6 @@ data:
         references:
           - id: fauna-uakaris
             displayName: Enrolled API
-            category: apihub-organization-apis
+            category: enrollment
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-uakaris
             uri: ""

--- a/traffic/000021/info.yaml
+++ b/traffic/000021/info.yaml
@@ -40,6 +40,6 @@ data:
         references:
           - id: fauna-vultures
             displayName: Enrolled API
-            category: apihub-organization-apis
+            category: enrollment
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-vultures
             uri: ""

--- a/traffic/000022/info.yaml
+++ b/traffic/000022/info.yaml
@@ -40,6 +40,6 @@ data:
         references:
           - id: fauna-whales
             displayName: Enrolled API
-            category: apihub-organization-apis
+            category: enrollment
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-whales
             uri: ""

--- a/traffic/000023/info.yaml
+++ b/traffic/000023/info.yaml
@@ -40,6 +40,6 @@ data:
         references:
           - id: fauna-xeruses
             displayName: Enrolled API
-            category: apihub-organization-apis
+            category: enrollment
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-xeruses
             uri: ""

--- a/traffic/000024/info.yaml
+++ b/traffic/000024/info.yaml
@@ -40,6 +40,6 @@ data:
         references:
           - id: fauna-yaks
             displayName: Enrolled API
-            category: apihub-organization-apis
+            category: enrollment
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-yaks
             uri: ""

--- a/traffic/000025/info.yaml
+++ b/traffic/000025/info.yaml
@@ -40,6 +40,6 @@ data:
         references:
           - id: fauna-zebras
             displayName: Enrolled API
-            category: apihub-organization-apis
+            category: enrollment
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-zebras
             uri: ""


### PR DESCRIPTION
This adds a "description" field to generated OpenAPI specs (indexed with `registry-bigquery index info`) and uses the `category` fields in `References` to  indicate the type of link being made (indexed with `registry-bigquery index links`).