### PR TITLE
Fix Spectral lint warnings.

### DIFF
--- a/apis/aardvarks/openapi.yaml
+++ b/apis/aardvarks/openapi.yaml
@@ -3,12 +3,20 @@ info:
   version: 1.0.0
   title: Fauna Aardvarks API
   description: Manage a collection of aardvarks.
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  contact:
+    name: Aardvark Support Team
+    email: aardvarks@apigee-apihub-demo.github.io
+    url: https://github.com/apigee-apihub-demo/animals
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:
   /aardvarks:
     get:
       summary: List all aardvarks
+      description: List all aardvarks
       operationId: listAardvarks
       tags:
         - aardvarks
@@ -39,6 +47,7 @@ paths:
                 $ref: '#/components/schemas/Error'
     post:
       summary: Create aardvark
+      description: Create aardvark
       operationId: createAardvark
       tags:
         - aardvarks
@@ -54,6 +63,7 @@ paths:
   /aardvarks/{aardvarkId}:
     get:
       summary: Info for a specific aardvark
+      description: Info for a specific aardvark
       operationId: getAardvark
       tags:
         - aardvarks
@@ -108,3 +118,6 @@ components:
           format: int32
         message:
           type: string
+tags:
+  - name: aardvarks
+    description: This API is about aardvarks.

--- a/apis/bandicoots/openapi.yaml
+++ b/apis/bandicoots/openapi.yaml
@@ -3,12 +3,20 @@ info:
   version: 1.0.0
   title: Fauna Bandicoots API
   description: Manage a collection of bandicoots.
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  contact:
+    name: Bandicoot Support Team
+    email: bandicoots@apigee-apihub-demo.github.io
+    url: https://github.com/apigee-apihub-demo/animals
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:
   /bandicoots:
     get:
       summary: List all bandicoots
+      description: List all bandicoots
       operationId: listBandicoots
       tags:
         - bandicoots
@@ -39,6 +47,7 @@ paths:
                 $ref: '#/components/schemas/Error'
     post:
       summary: Create bandicoot
+      description: Create bandicoot
       operationId: createBandicoot
       tags:
         - bandicoots
@@ -54,6 +63,7 @@ paths:
   /bandicoots/{bandicootId}:
     get:
       summary: Info for a specific bandicoot
+      description: Info for a specific bandicoot
       operationId: getBandicoot
       tags:
         - bandicoots
@@ -108,3 +118,6 @@ components:
           format: int32
         message:
           type: string
+tags:
+  - name: bandicoots
+    description: This API is about bandicoots.

--- a/apis/crocodiles/openapi.yaml
+++ b/apis/crocodiles/openapi.yaml
@@ -3,12 +3,20 @@ info:
   version: 1.0.0
   title: Fauna Crocodiles API
   description: Manage a collection of crocodiles.
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  contact:
+    name: Crocodile Support Team
+    email: crocodiles@apigee-apihub-demo.github.io
+    url: https://github.com/apigee-apihub-demo/animals
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:
   /crocodiles:
     get:
       summary: List all crocodiles
+      description: List all crocodiles
       operationId: listCrocodiles
       tags:
         - crocodiles
@@ -39,6 +47,7 @@ paths:
                 $ref: '#/components/schemas/Error'
     post:
       summary: Create crocodile
+      description: Create crocodile
       operationId: createCrocodile
       tags:
         - crocodiles
@@ -54,6 +63,7 @@ paths:
   /crocodiles/{crocodileId}:
     get:
       summary: Info for a specific crocodile
+      description: Info for a specific crocodile
       operationId: getCrocodile
       tags:
         - crocodiles
@@ -108,3 +118,6 @@ components:
           format: int32
         message:
           type: string
+tags:
+  - name: crocodiles
+    description: This API is about crocodiles.

--- a/apis/dolphins/openapi.yaml
+++ b/apis/dolphins/openapi.yaml
@@ -3,12 +3,20 @@ info:
   version: 1.0.0
   title: Fauna Dolphins API
   description: Manage a collection of dolphins.
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  contact:
+    name: Dolphin Support Team
+    email: dolphins@apigee-apihub-demo.github.io
+    url: https://github.com/apigee-apihub-demo/animals
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:
   /dolphins:
     get:
       summary: List all dolphins
+      description: List all dolphins
       operationId: listDolphins
       tags:
         - dolphins
@@ -39,6 +47,7 @@ paths:
                 $ref: '#/components/schemas/Error'
     post:
       summary: Create dolphin
+      description: Create dolphin
       operationId: createDolphin
       tags:
         - dolphins
@@ -54,6 +63,7 @@ paths:
   /dolphins/{dolphinId}:
     get:
       summary: Info for a specific dolphin
+      description: Info for a specific dolphin
       operationId: getDolphin
       tags:
         - dolphins
@@ -108,3 +118,6 @@ components:
           format: int32
         message:
           type: string
+tags:
+  - name: dolphins
+    description: This API is about dolphins.

--- a/apis/elephants/openapi.yaml
+++ b/apis/elephants/openapi.yaml
@@ -3,12 +3,20 @@ info:
   version: 1.0.0
   title: Fauna Elephants API
   description: Manage a collection of elephants.
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  contact:
+    name: Elephant Support Team
+    email: elephants@apigee-apihub-demo.github.io
+    url: https://github.com/apigee-apihub-demo/animals
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:
   /elephants:
     get:
       summary: List all elephants
+      description: List all elephants
       operationId: listElephants
       tags:
         - elephants
@@ -39,6 +47,7 @@ paths:
                 $ref: '#/components/schemas/Error'
     post:
       summary: Create elephant
+      description: Create elephant
       operationId: createElephant
       tags:
         - elephants
@@ -54,6 +63,7 @@ paths:
   /elephants/{elephantId}:
     get:
       summary: Info for a specific elephant
+      description: Info for a specific elephant
       operationId: getElephant
       tags:
         - elephants
@@ -108,3 +118,6 @@ components:
           format: int32
         message:
           type: string
+tags:
+  - name: elephants
+    description: This API is about elephants.

--- a/apis/flamingos/openapi.yaml
+++ b/apis/flamingos/openapi.yaml
@@ -3,12 +3,20 @@ info:
   version: 1.0.0
   title: Fauna Flamingos API
   description: Manage a collection of flamingos.
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  contact:
+    name: Flamingo Support Team
+    email: flamingos@apigee-apihub-demo.github.io
+    url: https://github.com/apigee-apihub-demo/animals
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:
   /flamingos:
     get:
       summary: List all flamingos
+      description: List all flamingos
       operationId: listFlamingos
       tags:
         - flamingos
@@ -39,6 +47,7 @@ paths:
                 $ref: '#/components/schemas/Error'
     post:
       summary: Create flamingo
+      description: Create flamingo
       operationId: createFlamingo
       tags:
         - flamingos
@@ -54,6 +63,7 @@ paths:
   /flamingos/{flamingoId}:
     get:
       summary: Info for a specific flamingo
+      description: Info for a specific flamingo
       operationId: getFlamingo
       tags:
         - flamingos
@@ -108,3 +118,6 @@ components:
       maxItems: 100
       items:
         $ref: '#/components/schemas/Flamingo'
+tags:
+  - name: flamingos
+    description: This API is about flamingos.

--- a/apis/giraffes/openapi.yaml
+++ b/apis/giraffes/openapi.yaml
@@ -3,12 +3,20 @@ info:
   version: 1.0.0
   title: Fauna Giraffes API
   description: Manage a collection of giraffes.
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  contact:
+    name: Giraffe Support Team
+    email: giraffes@apigee-apihub-demo.github.io
+    url: https://github.com/apigee-apihub-demo/animals
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:
   /giraffes:
     get:
       summary: List all giraffes
+      description: List all giraffes
       operationId: listGiraffes
       tags:
         - giraffes
@@ -39,6 +47,7 @@ paths:
                 $ref: '#/components/schemas/Error'
     post:
       summary: Create giraffe
+      description: Create giraffe
       operationId: createGiraffe
       tags:
         - giraffes
@@ -54,6 +63,7 @@ paths:
   /giraffes/{giraffeId}:
     get:
       summary: Info for a specific giraffe
+      description: Info for a specific giraffe
       operationId: getGiraffe
       tags:
         - giraffes
@@ -108,3 +118,6 @@ components:
       maxItems: 100
       items:
         $ref: '#/components/schemas/Giraffe'
+tags:
+  - name: giraffes
+    description: This API is about giraffes.

--- a/apis/hedgehogs/openapi.yaml
+++ b/apis/hedgehogs/openapi.yaml
@@ -3,12 +3,20 @@ info:
   version: 1.0.0
   title: Fauna Hedgehogs API
   description: Manage a collection of hedgehogs.
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  contact:
+    name: Hedgehog Support Team
+    email: hedgehogs@apigee-apihub-demo.github.io
+    url: https://github.com/apigee-apihub-demo/animals
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:
   /hedgehogs:
     get:
       summary: List all hedgehogs
+      description: List all hedgehogs
       operationId: listHedgehogs
       tags:
         - hedgehogs
@@ -39,6 +47,7 @@ paths:
                 $ref: '#/components/schemas/Error'
     post:
       summary: Create hedgehog
+      description: Create hedgehog
       operationId: createHedgehog
       tags:
         - hedgehogs
@@ -54,6 +63,7 @@ paths:
   /hedgehogs/{hedgehogId}:
     get:
       summary: Info for a specific hedgehog
+      description: Info for a specific hedgehog
       operationId: getHedgehog
       tags:
         - hedgehogs
@@ -108,3 +118,6 @@ components:
       maxItems: 100
       items:
         $ref: '#/components/schemas/Hedgehog'
+tags:
+  - name: hedgehogs
+    description: This API is about hedgehogs.

--- a/apis/iguanas/openapi.yaml
+++ b/apis/iguanas/openapi.yaml
@@ -3,12 +3,20 @@ info:
   version: 1.0.0
   title: Fauna Iguanas API
   description: Manage a collection of iguanas.
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  contact:
+    name: Iguana Support Team
+    email: iguanas@apigee-apihub-demo.github.io
+    url: https://github.com/apigee-apihub-demo/animals
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:
   /iguanas:
     get:
       summary: List all iguanas
+      description: List all iguanas
       operationId: listIguanas
       tags:
         - iguanas
@@ -39,6 +47,7 @@ paths:
                 $ref: '#/components/schemas/Error'
     post:
       summary: Create iguana
+      description: Create iguana
       operationId: createIguana
       tags:
         - iguanas
@@ -54,6 +63,7 @@ paths:
   /iguanas/{iguanaId}:
     get:
       summary: Info for a specific iguana
+      description: Info for a specific iguana
       operationId: getIguana
       tags:
         - iguanas
@@ -108,3 +118,6 @@ components:
       maxItems: 100
       items:
         $ref: '#/components/schemas/Iguana'
+tags:
+  - name: iguanas
+    description: This API is about iguanas.

--- a/apis/jaguars/openapi.yaml
+++ b/apis/jaguars/openapi.yaml
@@ -3,12 +3,20 @@ info:
   version: 1.0.0
   title: Fauna Jaguars API
   description: Manage a collection of jaguars.
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  contact:
+    name: Jaguar Support Team
+    email: jaguars@apigee-apihub-demo.github.io
+    url: https://github.com/apigee-apihub-demo/animals
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:
   /jaguars:
     get:
       summary: List all jaguars
+      description: List all jaguars
       operationId: listJaguars
       tags:
         - jaguars
@@ -39,6 +47,7 @@ paths:
                 $ref: '#/components/schemas/Error'
     post:
       summary: Create jaguar
+      description: Create jaguar
       operationId: createJaguar
       tags:
         - jaguars
@@ -54,6 +63,7 @@ paths:
   /jaguars/{jaguarId}:
     get:
       summary: Info for a specific jaguar
+      description: Info for a specific jaguar
       operationId: getJaguar
       tags:
         - jaguars
@@ -108,3 +118,6 @@ components:
       maxItems: 100
       items:
         $ref: '#/components/schemas/Jaguar'
+tags:
+  - name: jaguars
+    description: This API is about jaguars.

--- a/apis/kangaroos/openapi.yaml
+++ b/apis/kangaroos/openapi.yaml
@@ -3,12 +3,20 @@ info:
   version: 1.0.0
   title: Fauna Kangaroos API
   description: Manage a collection of kangaroos.
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  contact:
+    name: Kangaroo Support Team
+    email: kangaroos@apigee-apihub-demo.github.io
+    url: https://github.com/apigee-apihub-demo/animals
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:
   /kangaroos:
     get:
       summary: List all kangaroos
+      description: List all kangaroos
       operationId: listKangaroos
       tags:
         - kangaroos
@@ -39,6 +47,7 @@ paths:
                 $ref: '#/components/schemas/Error'
     post:
       summary: Create kangaroo
+      description: Create kangaroo
       operationId: createKangaroo
       tags:
         - kangaroos
@@ -54,6 +63,7 @@ paths:
   /kangaroos/{kangarooId}:
     get:
       summary: Info for a specific kangaroo
+      description: Info for a specific kangaroo
       operationId: getKangaroo
       tags:
         - kangaroos
@@ -108,3 +118,6 @@ components:
       maxItems: 100
       items:
         $ref: '#/components/schemas/Kangaroo'
+tags:
+  - name: kangaroos
+    description: This API is about kangaroos.

--- a/apis/lemurs/openapi.yaml
+++ b/apis/lemurs/openapi.yaml
@@ -3,12 +3,20 @@ info:
   version: 1.0.0
   title: Fauna Lemurs API
   description: Manage a collection of lemurs.
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  contact:
+    name: Lemur Support Team
+    email: lemurs@apigee-apihub-demo.github.io
+    url: https://github.com/apigee-apihub-demo/animals
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:
   /lemurs:
     get:
       summary: List all lemurs
+      description: List all lemurs
       operationId: listLemurs
       tags:
         - lemurs
@@ -39,6 +47,7 @@ paths:
                 $ref: '#/components/schemas/Error'
     post:
       summary: Create lemur
+      description: Create lemur
       operationId: createLemur
       tags:
         - lemurs
@@ -54,6 +63,7 @@ paths:
   /lemurs/{lemurId}:
     get:
       summary: Info for a specific lemur
+      description: Info for a specific lemur
       operationId: getLemur
       tags:
         - lemurs
@@ -108,3 +118,6 @@ components:
       maxItems: 100
       items:
         $ref: '#/components/schemas/Lemur'
+tags:
+  - name: lemurs
+    description: This API is about lemurs.

--- a/apis/monkeys/openapi.yaml
+++ b/apis/monkeys/openapi.yaml
@@ -3,12 +3,20 @@ info:
   version: 1.0.0
   title: Fauna Monkeys API
   description: Manage a collection of monkeys.
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  contact:
+    name: Monkey Support Team
+    email: monkeys@apigee-apihub-demo.github.io
+    url: https://github.com/apigee-apihub-demo/animals
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:
   /monkeys:
     get:
       summary: List all monkeys
+      description: List all monkeys
       operationId: listMonkeys
       tags:
         - monkeys
@@ -39,6 +47,7 @@ paths:
                 $ref: '#/components/schemas/Error'
     post:
       summary: Create monkey
+      description: Create monkey
       operationId: createMonkey
       tags:
         - monkeys
@@ -54,6 +63,7 @@ paths:
   /monkeys/{monkeyId}:
     get:
       summary: Info for a specific monkey
+      description: Info for a specific monkey
       operationId: getMonkey
       tags:
         - monkeys
@@ -108,3 +118,6 @@ components:
       maxItems: 100
       items:
         $ref: '#/components/schemas/Monkey'
+tags:
+  - name: monkeys
+    description: This API is about monkeys.

--- a/apis/nightingales/openapi.yaml
+++ b/apis/nightingales/openapi.yaml
@@ -3,12 +3,20 @@ info:
   version: 1.0.0
   title: Fauna Nightingales API
   description: Manage a collection of nightingales.
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  contact:
+    name: Nightingale Support Team
+    email: nightingales@apigee-apihub-demo.github.io
+    url: https://github.com/apigee-apihub-demo/animals
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:
   /nightingales:
     get:
       summary: List all nightingales
+      description: List all nightingales
       operationId: listNightingales
       tags:
         - nightingales
@@ -39,6 +47,7 @@ paths:
                 $ref: '#/components/schemas/Error'
     post:
       summary: Create nightingale
+      description: Create nightingale
       operationId: createNightingale
       tags:
         - nightingales
@@ -54,6 +63,7 @@ paths:
   /nightingales/{nightingaleId}:
     get:
       summary: Info for a specific nightingale
+      description: Info for a specific nightingale
       operationId: getNightingale
       tags:
         - nightingales
@@ -108,3 +118,6 @@ components:
       maxItems: 100
       items:
         $ref: '#/components/schemas/Nightingale'
+tags:
+  - name: nightingales
+    description: This API is about nightingales.

--- a/apis/ostriches/openapi.yaml
+++ b/apis/ostriches/openapi.yaml
@@ -3,12 +3,20 @@ info:
   version: 1.0.0
   title: Fauna Ostriches API
   description: Manage a collection of ostriches.
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  contact:
+    name: Ostrich Support Team
+    email: ostriches@apigee-apihub-demo.github.io
+    url: https://github.com/apigee-apihub-demo/animals
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:
   /ostriches:
     get:
       summary: List all ostriches
+      description: List all ostriches
       operationId: listOstriches
       tags:
         - ostriches
@@ -39,6 +47,7 @@ paths:
                 $ref: '#/components/schemas/Error'
     post:
       summary: Create ostrich
+      description: Create ostrich
       operationId: createOstrich
       tags:
         - ostriches
@@ -54,6 +63,7 @@ paths:
   /ostriches/{ostrichId}:
     get:
       summary: Info for a specific ostrich
+      description: Info for a specific ostrich
       operationId: getOstrich
       tags:
         - ostriches
@@ -108,3 +118,6 @@ components:
       maxItems: 100
       items:
         $ref: '#/components/schemas/Ostrich'
+tags:
+  - name: ostriches
+    description: This API is about ostriches.

--- a/apis/porcupines/openapi.yaml
+++ b/apis/porcupines/openapi.yaml
@@ -3,12 +3,20 @@ info:
   version: 1.0.0
   title: Fauna Porcupines API
   description: Manage a collection of porcupines.
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  contact:
+    name: Porcupine Support Team
+    email: porcupines@apigee-apihub-demo.github.io
+    url: https://github.com/apigee-apihub-demo/animals
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:
   /porcupines:
     get:
       summary: List all porcupines
+      description: List all porcupines
       operationId: listPorcupines
       tags:
         - porcupines
@@ -39,6 +47,7 @@ paths:
                 $ref: '#/components/schemas/Error'
     post:
       summary: Create porcupine
+      description: Create porcupine
       operationId: createPorcupine
       tags:
         - porcupines
@@ -54,6 +63,7 @@ paths:
   /porcupines/{porcupineId}:
     get:
       summary: Info for a specific porcupine
+      description: Info for a specific porcupine
       operationId: getPorcupine
       tags:
         - porcupines
@@ -108,3 +118,6 @@ components:
       maxItems: 100
       items:
         $ref: '#/components/schemas/Porcupine'
+tags:
+  - name: porcupines
+    description: This API is about porcupines.

--- a/apis/quokkas/openapi.yaml
+++ b/apis/quokkas/openapi.yaml
@@ -3,12 +3,20 @@ info:
   version: 1.0.0
   title: Fauna Quokkas API
   description: Manage a collection of quokkas.
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  contact:
+    name: Quokka Support Team
+    email: quokkas@apigee-apihub-demo.github.io
+    url: https://github.com/apigee-apihub-demo/animals
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:
   /quokkas:
     get:
       summary: List all quokkas
+      description: List all quokkas
       operationId: listQuokkas
       tags:
         - quokkas
@@ -39,6 +47,7 @@ paths:
                 $ref: '#/components/schemas/Error'
     post:
       summary: Create quokka
+      description: Create quokka
       operationId: createQuokka
       tags:
         - quokkas
@@ -54,6 +63,7 @@ paths:
   /quokkas/{quokkaId}:
     get:
       summary: Info for a specific quokka
+      description: Info for a specific quokka
       operationId: getQuokka
       tags:
         - quokkas
@@ -108,3 +118,6 @@ components:
       maxItems: 100
       items:
         $ref: '#/components/schemas/Quokka'
+tags:
+  - name: quokkas
+    description: This API is about quokkas.

--- a/apis/raccoons/openapi.yaml
+++ b/apis/raccoons/openapi.yaml
@@ -3,12 +3,20 @@ info:
   version: 1.0.0
   title: Fauna Raccoons API
   description: Manage a collection of raccoons.
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  contact:
+    name: Raccoon Support Team
+    email: raccoons@apigee-apihub-demo.github.io
+    url: https://github.com/apigee-apihub-demo/animals
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:
   /raccoons:
     get:
       summary: List all raccoons
+      description: List all raccoons
       operationId: listRaccoons
       tags:
         - raccoons
@@ -39,6 +47,7 @@ paths:
                 $ref: '#/components/schemas/Error'
     post:
       summary: Create raccoon
+      description: Create raccoon
       operationId: createRaccoon
       tags:
         - raccoons
@@ -54,6 +63,7 @@ paths:
   /raccoons/{raccoonId}:
     get:
       summary: Info for a specific raccoon
+      description: Info for a specific raccoon
       operationId: getRaccoon
       tags:
         - raccoons
@@ -108,3 +118,6 @@ components:
       maxItems: 100
       items:
         $ref: '#/components/schemas/Raccoon'
+tags:
+  - name: raccoons
+    description: This API is about raccoons.

--- a/apis/salamanders/openapi.yaml
+++ b/apis/salamanders/openapi.yaml
@@ -3,12 +3,20 @@ info:
   version: 1.0.0
   title: Fauna Salamanders API
   description: Manage a collection of salamanders.
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  contact:
+    name: Salamander Support Team
+    email: salamanders@apigee-apihub-demo.github.io
+    url: https://github.com/apigee-apihub-demo/animals
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:
   /salamanders:
     get:
       summary: List all salamanders
+      description: List all salamanders
       operationId: listSalamanders
       tags:
         - salamanders
@@ -39,6 +47,7 @@ paths:
                 $ref: '#/components/schemas/Error'
     post:
       summary: Create salamander
+      description: Create salamander
       operationId: createSalamander
       tags:
         - salamanders
@@ -54,6 +63,7 @@ paths:
   /salamanders/{salamanderId}:
     get:
       summary: Info for a specific salamander
+      description: Info for a specific salamander
       operationId: getSalamander
       tags:
         - salamanders
@@ -108,3 +118,6 @@ components:
       maxItems: 100
       items:
         $ref: '#/components/schemas/Salamander'
+tags:
+  - name: salamanders
+    description: This API is about salamanders.

--- a/apis/tortoises/openapi.yaml
+++ b/apis/tortoises/openapi.yaml
@@ -3,12 +3,20 @@ info:
   version: 1.0.0
   title: Fauna Tortoises API
   description: Manage a collection of tortoises.
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  contact:
+    name: Tortoise Support Team
+    email: tortoises@apigee-apihub-demo.github.io
+    url: https://github.com/apigee-apihub-demo/animals
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:
   /tortoises:
     get:
       summary: List all tortoises
+      description: List all tortoises
       operationId: listTortoises
       tags:
         - tortoises
@@ -39,6 +47,7 @@ paths:
                 $ref: '#/components/schemas/Error'
     post:
       summary: Create tortoise
+      description: Create tortoise
       operationId: createTortoise
       tags:
         - tortoises
@@ -54,6 +63,7 @@ paths:
   /tortoises/{tortoiseId}:
     get:
       summary: Info for a specific tortoise
+      description: Info for a specific tortoise
       operationId: getTortoise
       tags:
         - tortoises
@@ -108,3 +118,6 @@ components:
       maxItems: 100
       items:
         $ref: '#/components/schemas/Tortoise'
+tags:
+  - name: tortoises
+    description: This API is about tortoises.

--- a/apis/uakaris/openapi.yaml
+++ b/apis/uakaris/openapi.yaml
@@ -3,12 +3,20 @@ info:
   version: 1.0.0
   title: Fauna Uakaris API
   description: Manage a collection of uakaris.
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  contact:
+    name: Uakari Support Team
+    email: uakaris@apigee-apihub-demo.github.io
+    url: https://github.com/apigee-apihub-demo/animals
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:
   /uakaris:
     get:
       summary: List all uakaris
+      description: List all uakaris
       operationId: listUakaris
       tags:
         - uakaris
@@ -39,6 +47,7 @@ paths:
                 $ref: '#/components/schemas/Error'
     post:
       summary: Create uakari
+      description: Create uakari
       operationId: createUakari
       tags:
         - uakaris
@@ -54,6 +63,7 @@ paths:
   /uakaris/{uakariId}:
     get:
       summary: Info for a specific uakari
+      description: Info for a specific uakari
       operationId: getUakari
       tags:
         - uakaris
@@ -108,3 +118,6 @@ components:
       maxItems: 100
       items:
         $ref: '#/components/schemas/Uakari'
+tags:
+  - name: uakaris
+    description: This API is about uakaris.

--- a/apis/vultures/openapi.yaml
+++ b/apis/vultures/openapi.yaml
@@ -3,12 +3,20 @@ info:
   version: 1.0.0
   title: Fauna Vultures API
   description: Manage a collection of vultures.
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  contact:
+    name: Vulture Support Team
+    email: vultures@apigee-apihub-demo.github.io
+    url: https://github.com/apigee-apihub-demo/animals
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:
   /vultures:
     get:
       summary: List all vultures
+      description: List all vultures
       operationId: listVultures
       tags:
         - vultures
@@ -39,6 +47,7 @@ paths:
                 $ref: '#/components/schemas/Error'
     post:
       summary: Create vulture
+      description: Create vulture
       operationId: createVulture
       tags:
         - vultures
@@ -54,6 +63,7 @@ paths:
   /vultures/{vultureId}:
     get:
       summary: Info for a specific vulture
+      description: Info for a specific vulture
       operationId: getVulture
       tags:
         - vultures
@@ -108,3 +118,6 @@ components:
       maxItems: 100
       items:
         $ref: '#/components/schemas/Vulture'
+tags:
+  - name: vultures
+    description: This API is about vultures.

--- a/apis/whales/openapi.yaml
+++ b/apis/whales/openapi.yaml
@@ -3,12 +3,20 @@ info:
   version: 1.0.0
   title: Fauna Whales API
   description: Manage a collection of whales.
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  contact:
+    name: Whale Support Team
+    email: whales@apigee-apihub-demo.github.io
+    url: https://github.com/apigee-apihub-demo/animals
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:
   /whales:
     get:
       summary: List all whales
+      description: List all whales
       operationId: listWhales
       tags:
         - whales
@@ -39,6 +47,7 @@ paths:
                 $ref: '#/components/schemas/Error'
     post:
       summary: Create whale
+      description: Create whale
       operationId: createWhale
       tags:
         - whales
@@ -54,6 +63,7 @@ paths:
   /whales/{whaleId}:
     get:
       summary: Info for a specific whale
+      description: Info for a specific whale
       operationId: getWhale
       tags:
         - whales
@@ -108,3 +118,6 @@ components:
       maxItems: 100
       items:
         $ref: '#/components/schemas/Whale'
+tags:
+  - name: whales
+    description: This API is about whales.

--- a/apis/xeruses/openapi.yaml
+++ b/apis/xeruses/openapi.yaml
@@ -3,12 +3,20 @@ info:
   version: 1.0.0
   title: Fauna Xeruses API
   description: Manage a collection of xeruses.
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  contact:
+    name: Xerus Support Team
+    email: xeruses@apigee-apihub-demo.github.io
+    url: https://github.com/apigee-apihub-demo/animals
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:
   /xeruses:
     get:
       summary: List all xeruses
+      description: List all xeruses
       operationId: listXeruses
       tags:
         - xeruses
@@ -39,6 +47,7 @@ paths:
                 $ref: '#/components/schemas/Error'
     post:
       summary: Create xerus
+      description: Create xerus
       operationId: createXerus
       tags:
         - xeruses
@@ -54,6 +63,7 @@ paths:
   /xeruses/{xerusId}:
     get:
       summary: Info for a specific xerus
+      description: Info for a specific xerus
       operationId: getXerus
       tags:
         - xeruses
@@ -108,3 +118,6 @@ components:
       maxItems: 100
       items:
         $ref: '#/components/schemas/Xerus'
+tags:
+  - name: xeruses
+    description: This API is about xeruses.

--- a/apis/yaks/openapi.yaml
+++ b/apis/yaks/openapi.yaml
@@ -3,12 +3,20 @@ info:
   version: 1.0.0
   title: Fauna Yaks API
   description: Manage a collection of yaks.
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  contact:
+    name: Yak Support Team
+    email: yaks@apigee-apihub-demo.github.io
+    url: https://github.com/apigee-apihub-demo/animals
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:
   /yaks:
     get:
       summary: List all yaks
+      description: List all yaks
       operationId: listYaks
       tags:
         - yaks
@@ -39,6 +47,7 @@ paths:
                 $ref: '#/components/schemas/Error'
     post:
       summary: Create yak
+      description: Create yak
       operationId: createYak
       tags:
         - yaks
@@ -54,6 +63,7 @@ paths:
   /yaks/{yakId}:
     get:
       summary: Info for a specific yak
+      description: Info for a specific yak
       operationId: getYak
       tags:
         - yaks
@@ -108,3 +118,6 @@ components:
       maxItems: 100
       items:
         $ref: '#/components/schemas/Yak'
+tags:
+  - name: yaks
+    description: This API is about yaks.

--- a/apis/zebras/openapi.yaml
+++ b/apis/zebras/openapi.yaml
@@ -3,12 +3,20 @@ info:
   version: 1.0.0
   title: Fauna Zebras API
   description: Manage a collection of zebras.
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  contact:
+    name: Zebra Support Team
+    email: zebras@apigee-apihub-demo.github.io
+    url: https://github.com/apigee-apihub-demo/animals
 servers:
   - url: https://apigee-apihub-demo.github.io
 paths:
   /zebras:
     get:
       summary: List all zebras
+      description: List all zebras
       operationId: listZebras
       tags:
         - zebras
@@ -39,6 +47,7 @@ paths:
                 $ref: '#/components/schemas/Error'
     post:
       summary: Create zebra
+      description: Create zebra
       operationId: createZebra
       tags:
         - zebras
@@ -54,6 +63,7 @@ paths:
   /zebras/{zebraId}:
     get:
       summary: Info for a specific zebra
+      description: Info for a specific zebra
       operationId: getZebra
       tags:
         - zebras
@@ -108,3 +118,6 @@ components:
       maxItems: 100
       items:
         $ref: '#/components/schemas/Zebra'
+tags:
+  - name: zebras
+    description: This API is about zebras.

--- a/cmd/generate-animal-apis/enrolled.go
+++ b/cmd/generate-animal-apis/enrolled.go
@@ -231,6 +231,21 @@ func generateEnrollment(animal *Animal) error {
 			Version:     "1.0.0",
 			Title:       displayName,
 			Description: fmt.Sprintf("Manage a collection of %s.", lowerPlural),
+			License: &OpenAPIInfoLicense{
+				Name: "Apache 2.0",
+				Url:  "http://www.apache.org/licenses/LICENSE-2.0.html",
+			},
+			Contact: &OpenAPIInfoContact{
+				Name:  upperSingular + " Support Team",
+				Email: lowerPlural + "@apigee-apihub-demo.github.io",
+				Url:   "https://github.com/apigee-apihub-demo/animals",
+			},
+		},
+		Tags: []*OpenAPITag{
+			{
+				Name:        lowerPlural,
+				Description: fmt.Sprintf("This API is about %s.", lowerPlural),
+			},
 		},
 		Servers: []*OpenAPIServer{
 			{
@@ -241,6 +256,7 @@ func generateEnrollment(animal *Animal) error {
 			"/" + lowerPlural: {
 				Get: &OpenAPIOperation{
 					Summary:     "List all " + lowerPlural,
+					Description: "List all " + lowerPlural,
 					OperationID: "list" + upperPlural,
 					Tags:        []string{lowerPlural},
 					Parameters: []*OpenAPIParameter{
@@ -279,6 +295,7 @@ func generateEnrollment(animal *Animal) error {
 				},
 				Post: &OpenAPIOperation{
 					Summary:     "Create " + lowerSingular,
+					Description: "Create " + lowerSingular,
 					OperationID: "create" + upperSingular,
 					Tags:        []string{lowerPlural},
 					Responses: map[string]*OpenAPIResponse{
@@ -292,6 +309,7 @@ func generateEnrollment(animal *Animal) error {
 			"/" + lowerPlural + "/{" + lowerSingular + "Id}": {
 				Get: &OpenAPIOperation{
 					Summary:     "Info for a specific " + lowerSingular,
+					Description: "Info for a specific " + lowerSingular,
 					OperationID: "get" + upperSingular,
 					Tags:        []string{lowerPlural},
 					Parameters: []*OpenAPIParameter{

--- a/cmd/generate-animal-apis/openapi.go
+++ b/cmd/generate-animal-apis/openapi.go
@@ -20,12 +20,31 @@ type OpenAPI struct {
 	Servers    []*OpenAPIServer        `yaml:"servers,omitempty"`
 	Paths      map[string]*OpenAPIPath `yaml:"paths"`
 	Components *OpenAPIComponents      `yaml:"components,omitempty"`
+	Tags       []*OpenAPITag           `yaml:"tags,omitempty"`
+}
+
+type OpenAPITag struct {
+	Name        string `yaml:"name,omitempty"`
+	Description string `yaml:"description,omitempty"`
 }
 
 type OpenAPIInfo struct {
-	Version     string `yaml:"version,omitempty"`
-	Title       string `yaml:"title,omitempty"`
-	Description string `yaml:"description,omitempty"`
+	Version     string              `yaml:"version,omitempty"`
+	Title       string              `yaml:"title,omitempty"`
+	Description string              `yaml:"description,omitempty"`
+	License     *OpenAPIInfoLicense `yaml:"license,omitempty"`
+	Contact     *OpenAPIInfoContact `yaml:"contact,omitempty"`
+}
+
+type OpenAPIInfoLicense struct {
+	Name string `yaml:"name,omitempty"`
+	Url  string `yaml:"url,omitempty"`
+}
+
+type OpenAPIInfoContact struct {
+	Name  string `yaml:"name,omitempty"`
+	Email string `yaml:"email,omitempty"`
+	Url   string `yaml:"url,omitempty"`
 }
 
 type OpenAPIServer struct {
@@ -39,6 +58,7 @@ type OpenAPIPath struct {
 
 type OpenAPIOperation struct {
 	Summary     string                      `yaml:"summary,omitempty"`
+	Description string                      `yaml:"description,omitempty"`
 	OperationID string                      `yaml:"operationId,omitempty"`
 	Tags        []string                    `yaml:"tags,omitempty"`
 	Parameters  []*OpenAPIParameter         `yaml:"parameters,omitempty"`


### PR DESCRIPTION
This updates the OpenAPI spec generator to fix all of the Spectral-based lint warnings.

We might want to disable some of these changes (at least for selected APIs) so that there are warnings to display, but this at least sets a baseline.