### PR TITLE
Add additional detail to mock signal data

### DIFF
--- a/cmd/generate-animal-apis/enrolled.go
+++ b/cmd/generate-animal-apis/enrolled.go
@@ -34,6 +34,7 @@ const source = "generate-animal-apis"
 
 func enrolledCommand() *cobra.Command {
 	var filename string
+	var project string
 	cmd := &cobra.Command{
 		Use:   "enrolled",
 		Short: "Generate YAML for enrolled APIs",
@@ -44,7 +45,7 @@ func enrolledCommand() *cobra.Command {
 				return err
 			}
 			for _, animal := range animals.Animals {
-				if err = generateEnrollment(&animal); err != nil {
+				if err = generateEnrollment(project, &animal); err != nil {
 					return err
 				}
 			}
@@ -52,10 +53,11 @@ func enrolledCommand() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&filename, "filename", "animals.yaml", "Animals definition file (YAML)")
+	cmd.Flags().StringVar(&project, "project", "apigee-apihub-demo", "API Hub GCP project")
 	return cmd
 }
 
-func generateEnrollment(animal *Animal) error {
+func generateEnrollment(project string, animal *Animal) error {
 	upperSingular := animal.Name
 	lowerSingular := strings.ToLower(upperSingular)
 	upperPlural := pluralize.NewClient().Plural(animal.Name)

--- a/cmd/generate-animal-apis/runtime.go
+++ b/cmd/generate-animal-apis/runtime.go
@@ -89,6 +89,7 @@ func generateRuntimeMocks(animal *Animal) error {
 					"apihub-business-unit": organization,
 					"apihub-kind":          "proxy",
 					"apihub-source":        source,
+					"apihub-lifecycle":     "observed-proxy",
 				},
 				Annotations: map[string]string{
 					"proxy": organization + "/apis/" + provider + "-" + apiID,
@@ -182,6 +183,7 @@ func generateRuntimeMocks(animal *Animal) error {
 					"apihub-business-unit": organization,
 					"apihub-kind":          "product",
 					"apihub-target-users":  "public",
+					"apihub-lifecycle":     "observed-product",
 				},
 				Annotations: map[string]string{
 					"organization": "apigee-apihub-demo",

--- a/cmd/generate-animal-apis/runtime.go
+++ b/cmd/generate-animal-apis/runtime.go
@@ -111,7 +111,6 @@ func generateRuntimeMocks(project string, animal *Animal) error {
 					"apihub-business-unit": project,
 					"apihub-kind":          "proxy",
 					"apihub-source":        source,
-					"apihub-lifecycle":     "observed-proxy",
 				},
 				Annotations: map[string]string{
 					"proxy": project + "/apis/" + provider + "-" + apiID,
@@ -216,7 +215,6 @@ func generateRuntimeMocks(project string, animal *Animal) error {
 					"apihub-business-unit": project,
 					"apihub-kind":          "product",
 					"apihub-target-users":  "public",
-					"apihub-lifecycle":     "observed-product",
 				},
 				Annotations: map[string]string{
 					"organization": project,

--- a/cmd/generate-animal-apis/traffic.go
+++ b/cmd/generate-animal-apis/traffic.go
@@ -95,7 +95,6 @@ func generateTraffic(project string, id int, animal *Animal) error {
 				Labels: map[string]string{
 					"apihub-kind":         "traffic",
 					"apihub-source":       source,
-					"apihub-lifecycle":    "observed-traffic",
 					"apihub-target-users": "internal",
 				},
 				Annotations: map[string]string{},

--- a/cmd/generate-animal-apis/traffic.go
+++ b/cmd/generate-animal-apis/traffic.go
@@ -91,8 +91,9 @@ func generateTraffic(id int, animal *Animal) error {
 			Metadata: encoding.Metadata{
 				Name: trafficApiID,
 				Labels: map[string]string{
-					"apihub-kind":   "traffic",
-					"apihub-source": source,
+					"apihub-kind":      "traffic",
+					"apihub-source":    source,
+					"apihub-lifecycle": "observed-traffic",
 				},
 				Annotations: map[string]string{},
 			},

--- a/cmd/generate-animal-apis/traffic.go
+++ b/cmd/generate-animal-apis/traffic.go
@@ -28,6 +28,7 @@ import (
 
 func trafficCommand() *cobra.Command {
 	var filename string
+	var project string
 	cmd := &cobra.Command{
 		Use:   "traffic",
 		Short: "Generate YAML for mock traffic signals",
@@ -38,7 +39,7 @@ func trafficCommand() *cobra.Command {
 				return err
 			}
 			for i, animal := range animals.Animals {
-				if err = generateTraffic(i, &animal); err != nil {
+				if err = generateTraffic(project, i, &animal); err != nil {
 					return err
 				}
 			}
@@ -46,12 +47,13 @@ func trafficCommand() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&filename, "filename", "animals.yaml", "Animals definition file (YAML)")
+	cmd.Flags().StringVar(&project, "project", "apigee-apihub-demo", "API Hub GCP project")
 	return cmd
 }
 
 const traffic = "traffic"
 
-func generateTraffic(id int, animal *Animal) error {
+func generateTraffic(project string, id int, animal *Animal) error {
 	upperPlural := pluralize.NewClient().Plural(animal.Name)
 	lowerPlural := strings.ToLower(upperPlural)
 
@@ -59,7 +61,7 @@ func generateTraffic(id int, animal *Animal) error {
 
 	enrolledApiID := provider + "-" + strings.ToLower(lowerPlural)
 
-	trafficApiID := source + "-" + encodeName(organization+"-traffic-"+trafficID)
+	trafficApiID := source + "-" + encodeName(project+"-traffic-"+trafficID)
 	fmt.Printf("generating %+v API\n", trafficApiID)
 
 	// Create output directory.
@@ -76,8 +78,8 @@ func generateTraffic(id int, animal *Animal) error {
 			{
 				Id:          enrolledApiID,
 				DisplayName: "Enrolled API",
-				Category:    "enrollment",
-				Resource:    "projects/apigee-apihub-demo/locations/global/apis/" + enrolledApiID,
+				Category:    "apihub-organization-apis",
+				Resource:    "projects/" + project + "/locations/global/apis/" + enrolledApiID,
 			},
 		},
 	})
@@ -91,15 +93,18 @@ func generateTraffic(id int, animal *Animal) error {
 			Metadata: encoding.Metadata{
 				Name: trafficApiID,
 				Labels: map[string]string{
-					"apihub-kind":      "traffic",
-					"apihub-source":    source,
-					"apihub-lifecycle": "observed-traffic",
+					"apihub-kind":         "traffic",
+					"apihub-source":       source,
+					"apihub-lifecycle":    "observed-traffic",
+					"apihub-target-users": "internal",
 				},
 				Annotations: map[string]string{},
 			},
 		},
 		Data: encoding.ApiData{
-			DisplayName: fmt.Sprintf("Traffic Observation %s", trafficID),
+			DisplayName:           fmt.Sprintf("Traffic %s", trafficID),
+			RecommendedVersion:    "v1",
+			RecommendedDeployment: "example",
 			ApiVersions: []*encoding.ApiVersion{
 				{
 					Header: encoding.Header{
@@ -114,6 +119,7 @@ func generateTraffic(id int, animal *Animal) error {
 					Data: encoding.ApiVersionData{
 						DisplayName: "v1",
 						PrimarySpec: "openapi",
+						State:       "observed-traffic",
 						ApiSpecs: []*encoding.ApiSpec{
 							{
 								Header: encoding.Header{
@@ -138,11 +144,15 @@ func generateTraffic(id int, animal *Animal) error {
 				{
 					Header: encoding.Header{
 						Metadata: encoding.Metadata{
-							Name: "location",
+							Name: "example",
+							Labels: map[string]string{
+								"apihub-gateway": "apihub-unmanaged",
+							},
 						},
 					},
 					Data: encoding.ApiDeploymentData{
-						EndpointURI: "bar.org",
+						DisplayName: "example",
+						EndpointURI: "https://example.com",
 					},
 				},
 			},

--- a/runtime/aardvarks/info.yaml
+++ b/runtime/aardvarks/info.yaml
@@ -7,6 +7,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
+        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-aardvarks
@@ -46,6 +47,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
+        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/aardvarks/info.yaml
+++ b/runtime/aardvarks/info.yaml
@@ -12,7 +12,7 @@ items:
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-aardvarks
     data:
-      displayName: 'apigee-apihub-demo proxy: fauna-aardvarks'
+      displayName: Proxy apigee-apihub-demo-fauna-aardvarks
       recommendedVersion: v1
       deployments:
         - metadata:
@@ -31,6 +31,25 @@ items:
             displayName: test-env (bar.org)
             endpointURI: bar.org
       artifacts:
+        - kind: ReferenceList
+          metadata:
+            name: apihub-related
+            labels:
+              apihub-source: generate-animal-apis
+          data:
+            displayName: Related Resources
+            description: Links to resources in the registry.
+            references:
+              - id: fauna-aardvarks
+                displayName: fauna-aardvarks
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/fauna-aardvarks
+                uri: ""
+              - id: apigee-apihub-demo-petstore-product
+                displayName: 'apigee-apihub-demo product: petstore'
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-da7sm7js3vlv25kbcjmzovv3zgdwpgmr
+                uri: ""
         - kind: ReferenceList
           metadata:
             name: apihub-dependencies
@@ -53,7 +72,7 @@ items:
         organization: apigee-apihub-demo
         product: petstore
     data:
-      displayName: 'apigee-apihub-demo product: fauna-aardvarks'
+      displayName: Product apigee-apihub-demo-fauna-aardvarks
       artifacts:
         - kind: ReferenceList
           metadata:
@@ -66,12 +85,12 @@ items:
             references:
               - id: fauna-aardvarks
                 displayName: fauna-aardvarks
-                category: enrollment
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-aardvarks
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: proxy
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-ytikblczmnmc5wfn7wx2a62v2k677cqr
                 uri: ""
         - kind: ReferenceList

--- a/runtime/aardvarks/info.yaml
+++ b/runtime/aardvarks/info.yaml
@@ -7,7 +7,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
-        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-aardvarks
@@ -66,7 +65,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
-        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/bandicoots/info.yaml
+++ b/runtime/bandicoots/info.yaml
@@ -12,7 +12,7 @@ items:
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-bandicoots
     data:
-      displayName: 'apigee-apihub-demo proxy: fauna-bandicoots'
+      displayName: Proxy apigee-apihub-demo-fauna-bandicoots
       recommendedVersion: v1
       deployments:
         - metadata:
@@ -31,6 +31,25 @@ items:
             displayName: test-env (bar.org)
             endpointURI: bar.org
       artifacts:
+        - kind: ReferenceList
+          metadata:
+            name: apihub-related
+            labels:
+              apihub-source: generate-animal-apis
+          data:
+            displayName: Related Resources
+            description: Links to resources in the registry.
+            references:
+              - id: fauna-bandicoots
+                displayName: fauna-bandicoots
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/fauna-bandicoots
+                uri: ""
+              - id: apigee-apihub-demo-petstore-product
+                displayName: 'apigee-apihub-demo product: petstore'
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-bxfb5toykhtghq3itral2cxw6uipqy3q
+                uri: ""
         - kind: ReferenceList
           metadata:
             name: apihub-dependencies
@@ -53,7 +72,7 @@ items:
         organization: apigee-apihub-demo
         product: petstore
     data:
-      displayName: 'apigee-apihub-demo product: fauna-bandicoots'
+      displayName: Product apigee-apihub-demo-fauna-bandicoots
       artifacts:
         - kind: ReferenceList
           metadata:
@@ -66,12 +85,12 @@ items:
             references:
               - id: fauna-bandicoots
                 displayName: fauna-bandicoots
-                category: enrollment
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-bandicoots
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: proxy
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-4vajvc52av2p4te5llvmbqjjhvgewdw6
                 uri: ""
         - kind: ReferenceList

--- a/runtime/bandicoots/info.yaml
+++ b/runtime/bandicoots/info.yaml
@@ -7,7 +7,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
-        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-bandicoots
@@ -66,7 +65,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
-        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/bandicoots/info.yaml
+++ b/runtime/bandicoots/info.yaml
@@ -7,6 +7,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
+        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-bandicoots
@@ -46,6 +47,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
+        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/crocodiles/info.yaml
+++ b/runtime/crocodiles/info.yaml
@@ -7,7 +7,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
-        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-crocodiles
@@ -66,7 +65,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
-        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/crocodiles/info.yaml
+++ b/runtime/crocodiles/info.yaml
@@ -12,7 +12,7 @@ items:
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-crocodiles
     data:
-      displayName: 'apigee-apihub-demo proxy: fauna-crocodiles'
+      displayName: Proxy apigee-apihub-demo-fauna-crocodiles
       recommendedVersion: v1
       deployments:
         - metadata:
@@ -31,6 +31,25 @@ items:
             displayName: test-env (bar.org)
             endpointURI: bar.org
       artifacts:
+        - kind: ReferenceList
+          metadata:
+            name: apihub-related
+            labels:
+              apihub-source: generate-animal-apis
+          data:
+            displayName: Related Resources
+            description: Links to resources in the registry.
+            references:
+              - id: fauna-crocodiles
+                displayName: fauna-crocodiles
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/fauna-crocodiles
+                uri: ""
+              - id: apigee-apihub-demo-petstore-product
+                displayName: 'apigee-apihub-demo product: petstore'
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-grsvj26uatbtd2iirg23p4ucbvjjbmfw
+                uri: ""
         - kind: ReferenceList
           metadata:
             name: apihub-dependencies
@@ -53,7 +72,7 @@ items:
         organization: apigee-apihub-demo
         product: petstore
     data:
-      displayName: 'apigee-apihub-demo product: fauna-crocodiles'
+      displayName: Product apigee-apihub-demo-fauna-crocodiles
       artifacts:
         - kind: ReferenceList
           metadata:
@@ -66,12 +85,12 @@ items:
             references:
               - id: fauna-crocodiles
                 displayName: fauna-crocodiles
-                category: enrollment
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-crocodiles
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: proxy
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-xqxklnlxqea7vxvt7tahs6wgsoouw4lo
                 uri: ""
         - kind: ReferenceList

--- a/runtime/crocodiles/info.yaml
+++ b/runtime/crocodiles/info.yaml
@@ -7,6 +7,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
+        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-crocodiles
@@ -46,6 +47,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
+        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/dolphins/info.yaml
+++ b/runtime/dolphins/info.yaml
@@ -7,7 +7,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
-        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-dolphins
@@ -66,7 +65,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
-        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/dolphins/info.yaml
+++ b/runtime/dolphins/info.yaml
@@ -7,6 +7,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
+        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-dolphins
@@ -46,6 +47,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
+        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/dolphins/info.yaml
+++ b/runtime/dolphins/info.yaml
@@ -12,7 +12,7 @@ items:
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-dolphins
     data:
-      displayName: 'apigee-apihub-demo proxy: fauna-dolphins'
+      displayName: Proxy apigee-apihub-demo-fauna-dolphins
       recommendedVersion: v1
       deployments:
         - metadata:
@@ -31,6 +31,25 @@ items:
             displayName: test-env (bar.org)
             endpointURI: bar.org
       artifacts:
+        - kind: ReferenceList
+          metadata:
+            name: apihub-related
+            labels:
+              apihub-source: generate-animal-apis
+          data:
+            displayName: Related Resources
+            description: Links to resources in the registry.
+            references:
+              - id: fauna-dolphins
+                displayName: fauna-dolphins
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/fauna-dolphins
+                uri: ""
+              - id: apigee-apihub-demo-petstore-product
+                displayName: 'apigee-apihub-demo product: petstore'
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-74ntzkqfm2rm4owhh5yumatzbizgr54y
+                uri: ""
         - kind: ReferenceList
           metadata:
             name: apihub-dependencies
@@ -53,7 +72,7 @@ items:
         organization: apigee-apihub-demo
         product: petstore
     data:
-      displayName: 'apigee-apihub-demo product: fauna-dolphins'
+      displayName: Product apigee-apihub-demo-fauna-dolphins
       artifacts:
         - kind: ReferenceList
           metadata:
@@ -66,12 +85,12 @@ items:
             references:
               - id: fauna-dolphins
                 displayName: fauna-dolphins
-                category: enrollment
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-dolphins
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: proxy
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-32rrlf63wpt45ci4iimmkpk22rk33dk6
                 uri: ""
         - kind: ReferenceList

--- a/runtime/elephants/info.yaml
+++ b/runtime/elephants/info.yaml
@@ -7,6 +7,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
+        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-elephants
@@ -46,6 +47,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
+        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/elephants/info.yaml
+++ b/runtime/elephants/info.yaml
@@ -12,7 +12,7 @@ items:
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-elephants
     data:
-      displayName: 'apigee-apihub-demo proxy: fauna-elephants'
+      displayName: Proxy apigee-apihub-demo-fauna-elephants
       recommendedVersion: v1
       deployments:
         - metadata:
@@ -31,6 +31,25 @@ items:
             displayName: test-env (bar.org)
             endpointURI: bar.org
       artifacts:
+        - kind: ReferenceList
+          metadata:
+            name: apihub-related
+            labels:
+              apihub-source: generate-animal-apis
+          data:
+            displayName: Related Resources
+            description: Links to resources in the registry.
+            references:
+              - id: fauna-elephants
+                displayName: fauna-elephants
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/fauna-elephants
+                uri: ""
+              - id: apigee-apihub-demo-petstore-product
+                displayName: 'apigee-apihub-demo product: petstore'
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-jocxgs2q2bnrzbv4s7ratcj4j2ec5h5u
+                uri: ""
         - kind: ReferenceList
           metadata:
             name: apihub-dependencies
@@ -53,7 +72,7 @@ items:
         organization: apigee-apihub-demo
         product: petstore
     data:
-      displayName: 'apigee-apihub-demo product: fauna-elephants'
+      displayName: Product apigee-apihub-demo-fauna-elephants
       artifacts:
         - kind: ReferenceList
           metadata:
@@ -66,12 +85,12 @@ items:
             references:
               - id: fauna-elephants
                 displayName: fauna-elephants
-                category: enrollment
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-elephants
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: proxy
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-xyytpwxwfq6bslt3zoqrytogbrqyh4aa
                 uri: ""
         - kind: ReferenceList

--- a/runtime/elephants/info.yaml
+++ b/runtime/elephants/info.yaml
@@ -7,7 +7,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
-        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-elephants
@@ -66,7 +65,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
-        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/flamingos/info.yaml
+++ b/runtime/flamingos/info.yaml
@@ -7,6 +7,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
+        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-flamingos
@@ -46,6 +47,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
+        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/flamingos/info.yaml
+++ b/runtime/flamingos/info.yaml
@@ -7,7 +7,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
-        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-flamingos
@@ -66,7 +65,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
-        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/flamingos/info.yaml
+++ b/runtime/flamingos/info.yaml
@@ -12,7 +12,7 @@ items:
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-flamingos
     data:
-      displayName: 'apigee-apihub-demo proxy: fauna-flamingos'
+      displayName: Proxy apigee-apihub-demo-fauna-flamingos
       recommendedVersion: v1
       deployments:
         - metadata:
@@ -31,6 +31,25 @@ items:
             displayName: test-env (bar.org)
             endpointURI: bar.org
       artifacts:
+        - kind: ReferenceList
+          metadata:
+            name: apihub-related
+            labels:
+              apihub-source: generate-animal-apis
+          data:
+            displayName: Related Resources
+            description: Links to resources in the registry.
+            references:
+              - id: fauna-flamingos
+                displayName: fauna-flamingos
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/fauna-flamingos
+                uri: ""
+              - id: apigee-apihub-demo-petstore-product
+                displayName: 'apigee-apihub-demo product: petstore'
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-4psvzhlxrxbv64ubmmzb3flgxbzyhc57
+                uri: ""
         - kind: ReferenceList
           metadata:
             name: apihub-dependencies
@@ -53,7 +72,7 @@ items:
         organization: apigee-apihub-demo
         product: petstore
     data:
-      displayName: 'apigee-apihub-demo product: fauna-flamingos'
+      displayName: Product apigee-apihub-demo-fauna-flamingos
       artifacts:
         - kind: ReferenceList
           metadata:
@@ -66,12 +85,12 @@ items:
             references:
               - id: fauna-flamingos
                 displayName: fauna-flamingos
-                category: enrollment
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-flamingos
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: proxy
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-tmzxc4eqmhhfs7bdx7kcwxnr65bbh2wj
                 uri: ""
         - kind: ReferenceList

--- a/runtime/giraffes/info.yaml
+++ b/runtime/giraffes/info.yaml
@@ -7,6 +7,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
+        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-giraffes
@@ -46,6 +47,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
+        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/giraffes/info.yaml
+++ b/runtime/giraffes/info.yaml
@@ -12,7 +12,7 @@ items:
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-giraffes
     data:
-      displayName: 'apigee-apihub-demo proxy: fauna-giraffes'
+      displayName: Proxy apigee-apihub-demo-fauna-giraffes
       recommendedVersion: v1
       deployments:
         - metadata:
@@ -31,6 +31,25 @@ items:
             displayName: test-env (bar.org)
             endpointURI: bar.org
       artifacts:
+        - kind: ReferenceList
+          metadata:
+            name: apihub-related
+            labels:
+              apihub-source: generate-animal-apis
+          data:
+            displayName: Related Resources
+            description: Links to resources in the registry.
+            references:
+              - id: fauna-giraffes
+                displayName: fauna-giraffes
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/fauna-giraffes
+                uri: ""
+              - id: apigee-apihub-demo-petstore-product
+                displayName: 'apigee-apihub-demo product: petstore'
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-fgceqy5a4d26i6rb7dsp52wd2m6xjejv
+                uri: ""
         - kind: ReferenceList
           metadata:
             name: apihub-dependencies
@@ -53,7 +72,7 @@ items:
         organization: apigee-apihub-demo
         product: petstore
     data:
-      displayName: 'apigee-apihub-demo product: fauna-giraffes'
+      displayName: Product apigee-apihub-demo-fauna-giraffes
       artifacts:
         - kind: ReferenceList
           metadata:
@@ -66,12 +85,12 @@ items:
             references:
               - id: fauna-giraffes
                 displayName: fauna-giraffes
-                category: enrollment
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-giraffes
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: proxy
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-ksonaqi3oincuf2mnsis7qbagvsso42m
                 uri: ""
         - kind: ReferenceList

--- a/runtime/giraffes/info.yaml
+++ b/runtime/giraffes/info.yaml
@@ -7,7 +7,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
-        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-giraffes
@@ -66,7 +65,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
-        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/hedgehogs/info.yaml
+++ b/runtime/hedgehogs/info.yaml
@@ -12,7 +12,7 @@ items:
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-hedgehogs
     data:
-      displayName: 'apigee-apihub-demo proxy: fauna-hedgehogs'
+      displayName: Proxy apigee-apihub-demo-fauna-hedgehogs
       recommendedVersion: v1
       deployments:
         - metadata:
@@ -31,6 +31,25 @@ items:
             displayName: test-env (bar.org)
             endpointURI: bar.org
       artifacts:
+        - kind: ReferenceList
+          metadata:
+            name: apihub-related
+            labels:
+              apihub-source: generate-animal-apis
+          data:
+            displayName: Related Resources
+            description: Links to resources in the registry.
+            references:
+              - id: fauna-hedgehogs
+                displayName: fauna-hedgehogs
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/fauna-hedgehogs
+                uri: ""
+              - id: apigee-apihub-demo-petstore-product
+                displayName: 'apigee-apihub-demo product: petstore'
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-verbhsr3d2llb5npaeccrgavs6n3rjxw
+                uri: ""
         - kind: ReferenceList
           metadata:
             name: apihub-dependencies
@@ -53,7 +72,7 @@ items:
         organization: apigee-apihub-demo
         product: petstore
     data:
-      displayName: 'apigee-apihub-demo product: fauna-hedgehogs'
+      displayName: Product apigee-apihub-demo-fauna-hedgehogs
       artifacts:
         - kind: ReferenceList
           metadata:
@@ -66,12 +85,12 @@ items:
             references:
               - id: fauna-hedgehogs
                 displayName: fauna-hedgehogs
-                category: enrollment
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-hedgehogs
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: proxy
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-eah6eqfecoz53rh6slxsgmzpqqhmdpnd
                 uri: ""
         - kind: ReferenceList

--- a/runtime/hedgehogs/info.yaml
+++ b/runtime/hedgehogs/info.yaml
@@ -7,7 +7,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
-        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-hedgehogs
@@ -66,7 +65,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
-        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/hedgehogs/info.yaml
+++ b/runtime/hedgehogs/info.yaml
@@ -7,6 +7,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
+        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-hedgehogs
@@ -46,6 +47,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
+        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/iguanas/info.yaml
+++ b/runtime/iguanas/info.yaml
@@ -12,7 +12,7 @@ items:
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-iguanas
     data:
-      displayName: 'apigee-apihub-demo proxy: fauna-iguanas'
+      displayName: Proxy apigee-apihub-demo-fauna-iguanas
       recommendedVersion: v1
       deployments:
         - metadata:
@@ -31,6 +31,25 @@ items:
             displayName: test-env (bar.org)
             endpointURI: bar.org
       artifacts:
+        - kind: ReferenceList
+          metadata:
+            name: apihub-related
+            labels:
+              apihub-source: generate-animal-apis
+          data:
+            displayName: Related Resources
+            description: Links to resources in the registry.
+            references:
+              - id: fauna-iguanas
+                displayName: fauna-iguanas
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/fauna-iguanas
+                uri: ""
+              - id: apigee-apihub-demo-petstore-product
+                displayName: 'apigee-apihub-demo product: petstore'
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-6kwzosiiyozsf5bce23ggyv7los4vzuw
+                uri: ""
         - kind: ReferenceList
           metadata:
             name: apihub-dependencies
@@ -53,7 +72,7 @@ items:
         organization: apigee-apihub-demo
         product: petstore
     data:
-      displayName: 'apigee-apihub-demo product: fauna-iguanas'
+      displayName: Product apigee-apihub-demo-fauna-iguanas
       artifacts:
         - kind: ReferenceList
           metadata:
@@ -66,12 +85,12 @@ items:
             references:
               - id: fauna-iguanas
                 displayName: fauna-iguanas
-                category: enrollment
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-iguanas
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: proxy
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-tffcfostdipjs4muibmrv4rzcvzsapph
                 uri: ""
         - kind: ReferenceList

--- a/runtime/iguanas/info.yaml
+++ b/runtime/iguanas/info.yaml
@@ -7,7 +7,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
-        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-iguanas
@@ -66,7 +65,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
-        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/iguanas/info.yaml
+++ b/runtime/iguanas/info.yaml
@@ -7,6 +7,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
+        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-iguanas
@@ -46,6 +47,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
+        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/jaguars/info.yaml
+++ b/runtime/jaguars/info.yaml
@@ -12,7 +12,7 @@ items:
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-jaguars
     data:
-      displayName: 'apigee-apihub-demo proxy: fauna-jaguars'
+      displayName: Proxy apigee-apihub-demo-fauna-jaguars
       recommendedVersion: v1
       deployments:
         - metadata:
@@ -31,6 +31,25 @@ items:
             displayName: test-env (bar.org)
             endpointURI: bar.org
       artifacts:
+        - kind: ReferenceList
+          metadata:
+            name: apihub-related
+            labels:
+              apihub-source: generate-animal-apis
+          data:
+            displayName: Related Resources
+            description: Links to resources in the registry.
+            references:
+              - id: fauna-jaguars
+                displayName: fauna-jaguars
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/fauna-jaguars
+                uri: ""
+              - id: apigee-apihub-demo-petstore-product
+                displayName: 'apigee-apihub-demo product: petstore'
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-lkc47rqrrphmydgpwlrh3uhemjfmobch
+                uri: ""
         - kind: ReferenceList
           metadata:
             name: apihub-dependencies
@@ -53,7 +72,7 @@ items:
         organization: apigee-apihub-demo
         product: petstore
     data:
-      displayName: 'apigee-apihub-demo product: fauna-jaguars'
+      displayName: Product apigee-apihub-demo-fauna-jaguars
       artifacts:
         - kind: ReferenceList
           metadata:
@@ -66,12 +85,12 @@ items:
             references:
               - id: fauna-jaguars
                 displayName: fauna-jaguars
-                category: enrollment
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-jaguars
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: proxy
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-kfaghart3xehanaf57kgw2dm3k4fh7j7
                 uri: ""
         - kind: ReferenceList

--- a/runtime/jaguars/info.yaml
+++ b/runtime/jaguars/info.yaml
@@ -7,6 +7,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
+        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-jaguars
@@ -46,6 +47,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
+        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/jaguars/info.yaml
+++ b/runtime/jaguars/info.yaml
@@ -7,7 +7,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
-        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-jaguars
@@ -66,7 +65,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
-        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/kangaroos/info.yaml
+++ b/runtime/kangaroos/info.yaml
@@ -12,7 +12,7 @@ items:
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-kangaroos
     data:
-      displayName: 'apigee-apihub-demo proxy: fauna-kangaroos'
+      displayName: Proxy apigee-apihub-demo-fauna-kangaroos
       recommendedVersion: v1
       deployments:
         - metadata:
@@ -31,6 +31,25 @@ items:
             displayName: test-env (bar.org)
             endpointURI: bar.org
       artifacts:
+        - kind: ReferenceList
+          metadata:
+            name: apihub-related
+            labels:
+              apihub-source: generate-animal-apis
+          data:
+            displayName: Related Resources
+            description: Links to resources in the registry.
+            references:
+              - id: fauna-kangaroos
+                displayName: fauna-kangaroos
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/fauna-kangaroos
+                uri: ""
+              - id: apigee-apihub-demo-petstore-product
+                displayName: 'apigee-apihub-demo product: petstore'
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-lxniwsmfhdfrnopo74ucck3oy4u7cttd
+                uri: ""
         - kind: ReferenceList
           metadata:
             name: apihub-dependencies
@@ -53,7 +72,7 @@ items:
         organization: apigee-apihub-demo
         product: petstore
     data:
-      displayName: 'apigee-apihub-demo product: fauna-kangaroos'
+      displayName: Product apigee-apihub-demo-fauna-kangaroos
       artifacts:
         - kind: ReferenceList
           metadata:
@@ -66,12 +85,12 @@ items:
             references:
               - id: fauna-kangaroos
                 displayName: fauna-kangaroos
-                category: enrollment
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-kangaroos
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: proxy
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-v572ftq25ohhgwibelgriroaslcql7ys
                 uri: ""
         - kind: ReferenceList

--- a/runtime/kangaroos/info.yaml
+++ b/runtime/kangaroos/info.yaml
@@ -7,6 +7,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
+        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-kangaroos
@@ -46,6 +47,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
+        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/kangaroos/info.yaml
+++ b/runtime/kangaroos/info.yaml
@@ -7,7 +7,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
-        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-kangaroos
@@ -66,7 +65,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
-        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/lemurs/info.yaml
+++ b/runtime/lemurs/info.yaml
@@ -12,7 +12,7 @@ items:
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-lemurs
     data:
-      displayName: 'apigee-apihub-demo proxy: fauna-lemurs'
+      displayName: Proxy apigee-apihub-demo-fauna-lemurs
       recommendedVersion: v1
       deployments:
         - metadata:
@@ -31,6 +31,25 @@ items:
             displayName: test-env (bar.org)
             endpointURI: bar.org
       artifacts:
+        - kind: ReferenceList
+          metadata:
+            name: apihub-related
+            labels:
+              apihub-source: generate-animal-apis
+          data:
+            displayName: Related Resources
+            description: Links to resources in the registry.
+            references:
+              - id: fauna-lemurs
+                displayName: fauna-lemurs
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/fauna-lemurs
+                uri: ""
+              - id: apigee-apihub-demo-petstore-product
+                displayName: 'apigee-apihub-demo product: petstore'
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-zc4bt6zdjikszv6ichqubbnfyifzmkzj
+                uri: ""
         - kind: ReferenceList
           metadata:
             name: apihub-dependencies
@@ -53,7 +72,7 @@ items:
         organization: apigee-apihub-demo
         product: petstore
     data:
-      displayName: 'apigee-apihub-demo product: fauna-lemurs'
+      displayName: Product apigee-apihub-demo-fauna-lemurs
       artifacts:
         - kind: ReferenceList
           metadata:
@@ -66,12 +85,12 @@ items:
             references:
               - id: fauna-lemurs
                 displayName: fauna-lemurs
-                category: enrollment
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-lemurs
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: proxy
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-67b4fq7hbanxrevgdtafmbjsc3ixi46p
                 uri: ""
         - kind: ReferenceList

--- a/runtime/lemurs/info.yaml
+++ b/runtime/lemurs/info.yaml
@@ -7,7 +7,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
-        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-lemurs
@@ -66,7 +65,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
-        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/lemurs/info.yaml
+++ b/runtime/lemurs/info.yaml
@@ -7,6 +7,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
+        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-lemurs
@@ -46,6 +47,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
+        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/monkeys/info.yaml
+++ b/runtime/monkeys/info.yaml
@@ -12,7 +12,7 @@ items:
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-monkeys
     data:
-      displayName: 'apigee-apihub-demo proxy: fauna-monkeys'
+      displayName: Proxy apigee-apihub-demo-fauna-monkeys
       recommendedVersion: v1
       deployments:
         - metadata:
@@ -31,6 +31,25 @@ items:
             displayName: test-env (bar.org)
             endpointURI: bar.org
       artifacts:
+        - kind: ReferenceList
+          metadata:
+            name: apihub-related
+            labels:
+              apihub-source: generate-animal-apis
+          data:
+            displayName: Related Resources
+            description: Links to resources in the registry.
+            references:
+              - id: fauna-monkeys
+                displayName: fauna-monkeys
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/fauna-monkeys
+                uri: ""
+              - id: apigee-apihub-demo-petstore-product
+                displayName: 'apigee-apihub-demo product: petstore'
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-jiiedzpzupsixri6crgkmpehrgsx5zhy
+                uri: ""
         - kind: ReferenceList
           metadata:
             name: apihub-dependencies
@@ -53,7 +72,7 @@ items:
         organization: apigee-apihub-demo
         product: petstore
     data:
-      displayName: 'apigee-apihub-demo product: fauna-monkeys'
+      displayName: Product apigee-apihub-demo-fauna-monkeys
       artifacts:
         - kind: ReferenceList
           metadata:
@@ -66,12 +85,12 @@ items:
             references:
               - id: fauna-monkeys
                 displayName: fauna-monkeys
-                category: enrollment
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-monkeys
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: proxy
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-2h5lmfcyxkhnqj3eaiiwid3gyp6gs75n
                 uri: ""
         - kind: ReferenceList

--- a/runtime/monkeys/info.yaml
+++ b/runtime/monkeys/info.yaml
@@ -7,7 +7,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
-        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-monkeys
@@ -66,7 +65,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
-        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/monkeys/info.yaml
+++ b/runtime/monkeys/info.yaml
@@ -7,6 +7,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
+        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-monkeys
@@ -46,6 +47,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
+        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/nightingales/info.yaml
+++ b/runtime/nightingales/info.yaml
@@ -12,7 +12,7 @@ items:
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-nightingales
     data:
-      displayName: 'apigee-apihub-demo proxy: fauna-nightingales'
+      displayName: Proxy apigee-apihub-demo-fauna-nightingales
       recommendedVersion: v1
       deployments:
         - metadata:
@@ -31,6 +31,25 @@ items:
             displayName: test-env (bar.org)
             endpointURI: bar.org
       artifacts:
+        - kind: ReferenceList
+          metadata:
+            name: apihub-related
+            labels:
+              apihub-source: generate-animal-apis
+          data:
+            displayName: Related Resources
+            description: Links to resources in the registry.
+            references:
+              - id: fauna-nightingales
+                displayName: fauna-nightingales
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/fauna-nightingales
+                uri: ""
+              - id: apigee-apihub-demo-petstore-product
+                displayName: 'apigee-apihub-demo product: petstore'
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-ug4mkjzuucequkibt7ycu5as2jwmxml7
+                uri: ""
         - kind: ReferenceList
           metadata:
             name: apihub-dependencies
@@ -53,7 +72,7 @@ items:
         organization: apigee-apihub-demo
         product: petstore
     data:
-      displayName: 'apigee-apihub-demo product: fauna-nightingales'
+      displayName: Product apigee-apihub-demo-fauna-nightingales
       artifacts:
         - kind: ReferenceList
           metadata:
@@ -66,12 +85,12 @@ items:
             references:
               - id: fauna-nightingales
                 displayName: fauna-nightingales
-                category: enrollment
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-nightingales
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: proxy
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-4t67owiqj76ijdva736s6uodsefieuly
                 uri: ""
         - kind: ReferenceList

--- a/runtime/nightingales/info.yaml
+++ b/runtime/nightingales/info.yaml
@@ -7,7 +7,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
-        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-nightingales
@@ -66,7 +65,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
-        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/nightingales/info.yaml
+++ b/runtime/nightingales/info.yaml
@@ -7,6 +7,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
+        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-nightingales
@@ -46,6 +47,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
+        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/ostriches/info.yaml
+++ b/runtime/ostriches/info.yaml
@@ -7,7 +7,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
-        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-ostriches
@@ -66,7 +65,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
-        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/ostriches/info.yaml
+++ b/runtime/ostriches/info.yaml
@@ -7,6 +7,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
+        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-ostriches
@@ -46,6 +47,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
+        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/ostriches/info.yaml
+++ b/runtime/ostriches/info.yaml
@@ -12,7 +12,7 @@ items:
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-ostriches
     data:
-      displayName: 'apigee-apihub-demo proxy: fauna-ostriches'
+      displayName: Proxy apigee-apihub-demo-fauna-ostriches
       recommendedVersion: v1
       deployments:
         - metadata:
@@ -31,6 +31,25 @@ items:
             displayName: test-env (bar.org)
             endpointURI: bar.org
       artifacts:
+        - kind: ReferenceList
+          metadata:
+            name: apihub-related
+            labels:
+              apihub-source: generate-animal-apis
+          data:
+            displayName: Related Resources
+            description: Links to resources in the registry.
+            references:
+              - id: fauna-ostriches
+                displayName: fauna-ostriches
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/fauna-ostriches
+                uri: ""
+              - id: apigee-apihub-demo-petstore-product
+                displayName: 'apigee-apihub-demo product: petstore'
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-mmw3tvbto4va24yrkdcfyhkge2icb7od
+                uri: ""
         - kind: ReferenceList
           metadata:
             name: apihub-dependencies
@@ -53,7 +72,7 @@ items:
         organization: apigee-apihub-demo
         product: petstore
     data:
-      displayName: 'apigee-apihub-demo product: fauna-ostriches'
+      displayName: Product apigee-apihub-demo-fauna-ostriches
       artifacts:
         - kind: ReferenceList
           metadata:
@@ -66,12 +85,12 @@ items:
             references:
               - id: fauna-ostriches
                 displayName: fauna-ostriches
-                category: enrollment
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-ostriches
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: proxy
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-py424mivw2biwyvf3n4rhkawf6tmncwa
                 uri: ""
         - kind: ReferenceList

--- a/runtime/porcupines/info.yaml
+++ b/runtime/porcupines/info.yaml
@@ -12,7 +12,7 @@ items:
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-porcupines
     data:
-      displayName: 'apigee-apihub-demo proxy: fauna-porcupines'
+      displayName: Proxy apigee-apihub-demo-fauna-porcupines
       recommendedVersion: v1
       deployments:
         - metadata:
@@ -31,6 +31,25 @@ items:
             displayName: test-env (bar.org)
             endpointURI: bar.org
       artifacts:
+        - kind: ReferenceList
+          metadata:
+            name: apihub-related
+            labels:
+              apihub-source: generate-animal-apis
+          data:
+            displayName: Related Resources
+            description: Links to resources in the registry.
+            references:
+              - id: fauna-porcupines
+                displayName: fauna-porcupines
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/fauna-porcupines
+                uri: ""
+              - id: apigee-apihub-demo-petstore-product
+                displayName: 'apigee-apihub-demo product: petstore'
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-r7wosnc4oye6bbj6f7islpj33q76cul3
+                uri: ""
         - kind: ReferenceList
           metadata:
             name: apihub-dependencies
@@ -53,7 +72,7 @@ items:
         organization: apigee-apihub-demo
         product: petstore
     data:
-      displayName: 'apigee-apihub-demo product: fauna-porcupines'
+      displayName: Product apigee-apihub-demo-fauna-porcupines
       artifacts:
         - kind: ReferenceList
           metadata:
@@ -66,12 +85,12 @@ items:
             references:
               - id: fauna-porcupines
                 displayName: fauna-porcupines
-                category: enrollment
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-porcupines
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: proxy
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-4tmq457kfloyaeb65ka4rzzkrpmrokxa
                 uri: ""
         - kind: ReferenceList

--- a/runtime/porcupines/info.yaml
+++ b/runtime/porcupines/info.yaml
@@ -7,7 +7,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
-        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-porcupines
@@ -66,7 +65,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
-        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/porcupines/info.yaml
+++ b/runtime/porcupines/info.yaml
@@ -7,6 +7,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
+        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-porcupines
@@ -46,6 +47,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
+        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/quokkas/info.yaml
+++ b/runtime/quokkas/info.yaml
@@ -7,6 +7,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
+        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-quokkas
@@ -46,6 +47,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
+        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/quokkas/info.yaml
+++ b/runtime/quokkas/info.yaml
@@ -12,7 +12,7 @@ items:
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-quokkas
     data:
-      displayName: 'apigee-apihub-demo proxy: fauna-quokkas'
+      displayName: Proxy apigee-apihub-demo-fauna-quokkas
       recommendedVersion: v1
       deployments:
         - metadata:
@@ -31,6 +31,25 @@ items:
             displayName: test-env (bar.org)
             endpointURI: bar.org
       artifacts:
+        - kind: ReferenceList
+          metadata:
+            name: apihub-related
+            labels:
+              apihub-source: generate-animal-apis
+          data:
+            displayName: Related Resources
+            description: Links to resources in the registry.
+            references:
+              - id: fauna-quokkas
+                displayName: fauna-quokkas
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/fauna-quokkas
+                uri: ""
+              - id: apigee-apihub-demo-petstore-product
+                displayName: 'apigee-apihub-demo product: petstore'
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-6wzxcyeyglihkwesjlkkgweifupg4jay
+                uri: ""
         - kind: ReferenceList
           metadata:
             name: apihub-dependencies
@@ -53,7 +72,7 @@ items:
         organization: apigee-apihub-demo
         product: petstore
     data:
-      displayName: 'apigee-apihub-demo product: fauna-quokkas'
+      displayName: Product apigee-apihub-demo-fauna-quokkas
       artifacts:
         - kind: ReferenceList
           metadata:
@@ -66,12 +85,12 @@ items:
             references:
               - id: fauna-quokkas
                 displayName: fauna-quokkas
-                category: enrollment
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-quokkas
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: proxy
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-h76ptgcunz5hj6kmcp6obkqtnjfeoo6o
                 uri: ""
         - kind: ReferenceList

--- a/runtime/quokkas/info.yaml
+++ b/runtime/quokkas/info.yaml
@@ -7,7 +7,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
-        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-quokkas
@@ -66,7 +65,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
-        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/raccoons/info.yaml
+++ b/runtime/raccoons/info.yaml
@@ -7,6 +7,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
+        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-raccoons
@@ -46,6 +47,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
+        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/raccoons/info.yaml
+++ b/runtime/raccoons/info.yaml
@@ -12,7 +12,7 @@ items:
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-raccoons
     data:
-      displayName: 'apigee-apihub-demo proxy: fauna-raccoons'
+      displayName: Proxy apigee-apihub-demo-fauna-raccoons
       recommendedVersion: v1
       deployments:
         - metadata:
@@ -31,6 +31,25 @@ items:
             displayName: test-env (bar.org)
             endpointURI: bar.org
       artifacts:
+        - kind: ReferenceList
+          metadata:
+            name: apihub-related
+            labels:
+              apihub-source: generate-animal-apis
+          data:
+            displayName: Related Resources
+            description: Links to resources in the registry.
+            references:
+              - id: fauna-raccoons
+                displayName: fauna-raccoons
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/fauna-raccoons
+                uri: ""
+              - id: apigee-apihub-demo-petstore-product
+                displayName: 'apigee-apihub-demo product: petstore'
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-sng6jt6ixad53egzju4kwjwipjd2zoe6
+                uri: ""
         - kind: ReferenceList
           metadata:
             name: apihub-dependencies
@@ -53,7 +72,7 @@ items:
         organization: apigee-apihub-demo
         product: petstore
     data:
-      displayName: 'apigee-apihub-demo product: fauna-raccoons'
+      displayName: Product apigee-apihub-demo-fauna-raccoons
       artifacts:
         - kind: ReferenceList
           metadata:
@@ -66,12 +85,12 @@ items:
             references:
               - id: fauna-raccoons
                 displayName: fauna-raccoons
-                category: enrollment
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-raccoons
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: proxy
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-a6dzq53bhwi7xbbxt4im3yyylrftlsnk
                 uri: ""
         - kind: ReferenceList

--- a/runtime/raccoons/info.yaml
+++ b/runtime/raccoons/info.yaml
@@ -7,7 +7,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
-        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-raccoons
@@ -66,7 +65,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
-        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/salamanders/info.yaml
+++ b/runtime/salamanders/info.yaml
@@ -12,7 +12,7 @@ items:
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-salamanders
     data:
-      displayName: 'apigee-apihub-demo proxy: fauna-salamanders'
+      displayName: Proxy apigee-apihub-demo-fauna-salamanders
       recommendedVersion: v1
       deployments:
         - metadata:
@@ -31,6 +31,25 @@ items:
             displayName: test-env (bar.org)
             endpointURI: bar.org
       artifacts:
+        - kind: ReferenceList
+          metadata:
+            name: apihub-related
+            labels:
+              apihub-source: generate-animal-apis
+          data:
+            displayName: Related Resources
+            description: Links to resources in the registry.
+            references:
+              - id: fauna-salamanders
+                displayName: fauna-salamanders
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/fauna-salamanders
+                uri: ""
+              - id: apigee-apihub-demo-petstore-product
+                displayName: 'apigee-apihub-demo product: petstore'
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-l4jlui3gzi2umx27gbd6qfya3hkeovri
+                uri: ""
         - kind: ReferenceList
           metadata:
             name: apihub-dependencies
@@ -53,7 +72,7 @@ items:
         organization: apigee-apihub-demo
         product: petstore
     data:
-      displayName: 'apigee-apihub-demo product: fauna-salamanders'
+      displayName: Product apigee-apihub-demo-fauna-salamanders
       artifacts:
         - kind: ReferenceList
           metadata:
@@ -66,12 +85,12 @@ items:
             references:
               - id: fauna-salamanders
                 displayName: fauna-salamanders
-                category: enrollment
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-salamanders
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: proxy
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-fd7qlg2zugrin3iuk7t2ynybzcej6an4
                 uri: ""
         - kind: ReferenceList

--- a/runtime/salamanders/info.yaml
+++ b/runtime/salamanders/info.yaml
@@ -7,7 +7,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
-        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-salamanders
@@ -66,7 +65,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
-        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/salamanders/info.yaml
+++ b/runtime/salamanders/info.yaml
@@ -7,6 +7,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
+        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-salamanders
@@ -46,6 +47,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
+        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/tortoises/info.yaml
+++ b/runtime/tortoises/info.yaml
@@ -7,6 +7,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
+        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-tortoises
@@ -46,6 +47,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
+        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/tortoises/info.yaml
+++ b/runtime/tortoises/info.yaml
@@ -12,7 +12,7 @@ items:
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-tortoises
     data:
-      displayName: 'apigee-apihub-demo proxy: fauna-tortoises'
+      displayName: Proxy apigee-apihub-demo-fauna-tortoises
       recommendedVersion: v1
       deployments:
         - metadata:
@@ -31,6 +31,25 @@ items:
             displayName: test-env (bar.org)
             endpointURI: bar.org
       artifacts:
+        - kind: ReferenceList
+          metadata:
+            name: apihub-related
+            labels:
+              apihub-source: generate-animal-apis
+          data:
+            displayName: Related Resources
+            description: Links to resources in the registry.
+            references:
+              - id: fauna-tortoises
+                displayName: fauna-tortoises
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/fauna-tortoises
+                uri: ""
+              - id: apigee-apihub-demo-petstore-product
+                displayName: 'apigee-apihub-demo product: petstore'
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-r2r6mjf5hwsfcowi3jv7wzxtil4wrqk7
+                uri: ""
         - kind: ReferenceList
           metadata:
             name: apihub-dependencies
@@ -53,7 +72,7 @@ items:
         organization: apigee-apihub-demo
         product: petstore
     data:
-      displayName: 'apigee-apihub-demo product: fauna-tortoises'
+      displayName: Product apigee-apihub-demo-fauna-tortoises
       artifacts:
         - kind: ReferenceList
           metadata:
@@ -66,12 +85,12 @@ items:
             references:
               - id: fauna-tortoises
                 displayName: fauna-tortoises
-                category: enrollment
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-tortoises
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: proxy
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-vwmvyhthleh4dz2wak4yfo3754o22u7g
                 uri: ""
         - kind: ReferenceList

--- a/runtime/tortoises/info.yaml
+++ b/runtime/tortoises/info.yaml
@@ -7,7 +7,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
-        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-tortoises
@@ -66,7 +65,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
-        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/uakaris/info.yaml
+++ b/runtime/uakaris/info.yaml
@@ -12,7 +12,7 @@ items:
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-uakaris
     data:
-      displayName: 'apigee-apihub-demo proxy: fauna-uakaris'
+      displayName: Proxy apigee-apihub-demo-fauna-uakaris
       recommendedVersion: v1
       deployments:
         - metadata:
@@ -31,6 +31,25 @@ items:
             displayName: test-env (bar.org)
             endpointURI: bar.org
       artifacts:
+        - kind: ReferenceList
+          metadata:
+            name: apihub-related
+            labels:
+              apihub-source: generate-animal-apis
+          data:
+            displayName: Related Resources
+            description: Links to resources in the registry.
+            references:
+              - id: fauna-uakaris
+                displayName: fauna-uakaris
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/fauna-uakaris
+                uri: ""
+              - id: apigee-apihub-demo-petstore-product
+                displayName: 'apigee-apihub-demo product: petstore'
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-d7ldoky4riza3aeff2nnjxgi3ecgm7ux
+                uri: ""
         - kind: ReferenceList
           metadata:
             name: apihub-dependencies
@@ -53,7 +72,7 @@ items:
         organization: apigee-apihub-demo
         product: petstore
     data:
-      displayName: 'apigee-apihub-demo product: fauna-uakaris'
+      displayName: Product apigee-apihub-demo-fauna-uakaris
       artifacts:
         - kind: ReferenceList
           metadata:
@@ -66,12 +85,12 @@ items:
             references:
               - id: fauna-uakaris
                 displayName: fauna-uakaris
-                category: enrollment
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-uakaris
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: proxy
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-ynbahv4jwfxjy5svkrnf7tpqao3pcqjo
                 uri: ""
         - kind: ReferenceList

--- a/runtime/uakaris/info.yaml
+++ b/runtime/uakaris/info.yaml
@@ -7,7 +7,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
-        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-uakaris
@@ -66,7 +65,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
-        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/uakaris/info.yaml
+++ b/runtime/uakaris/info.yaml
@@ -7,6 +7,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
+        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-uakaris
@@ -46,6 +47,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
+        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/vultures/info.yaml
+++ b/runtime/vultures/info.yaml
@@ -12,7 +12,7 @@ items:
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-vultures
     data:
-      displayName: 'apigee-apihub-demo proxy: fauna-vultures'
+      displayName: Proxy apigee-apihub-demo-fauna-vultures
       recommendedVersion: v1
       deployments:
         - metadata:
@@ -31,6 +31,25 @@ items:
             displayName: test-env (bar.org)
             endpointURI: bar.org
       artifacts:
+        - kind: ReferenceList
+          metadata:
+            name: apihub-related
+            labels:
+              apihub-source: generate-animal-apis
+          data:
+            displayName: Related Resources
+            description: Links to resources in the registry.
+            references:
+              - id: fauna-vultures
+                displayName: fauna-vultures
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/fauna-vultures
+                uri: ""
+              - id: apigee-apihub-demo-petstore-product
+                displayName: 'apigee-apihub-demo product: petstore'
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-eeqkmnigsfvu5fyspeie2ltxcj3qxy5s
+                uri: ""
         - kind: ReferenceList
           metadata:
             name: apihub-dependencies
@@ -53,7 +72,7 @@ items:
         organization: apigee-apihub-demo
         product: petstore
     data:
-      displayName: 'apigee-apihub-demo product: fauna-vultures'
+      displayName: Product apigee-apihub-demo-fauna-vultures
       artifacts:
         - kind: ReferenceList
           metadata:
@@ -66,12 +85,12 @@ items:
             references:
               - id: fauna-vultures
                 displayName: fauna-vultures
-                category: enrollment
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-vultures
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: proxy
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-nquasooumwze5rokykwvn5ez4pxthrqr
                 uri: ""
         - kind: ReferenceList

--- a/runtime/vultures/info.yaml
+++ b/runtime/vultures/info.yaml
@@ -7,6 +7,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
+        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-vultures
@@ -46,6 +47,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
+        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/vultures/info.yaml
+++ b/runtime/vultures/info.yaml
@@ -7,7 +7,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
-        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-vultures
@@ -66,7 +65,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
-        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/whales/info.yaml
+++ b/runtime/whales/info.yaml
@@ -7,7 +7,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
-        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-whales
@@ -66,7 +65,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
-        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/whales/info.yaml
+++ b/runtime/whales/info.yaml
@@ -12,7 +12,7 @@ items:
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-whales
     data:
-      displayName: 'apigee-apihub-demo proxy: fauna-whales'
+      displayName: Proxy apigee-apihub-demo-fauna-whales
       recommendedVersion: v1
       deployments:
         - metadata:
@@ -31,6 +31,25 @@ items:
             displayName: test-env (bar.org)
             endpointURI: bar.org
       artifacts:
+        - kind: ReferenceList
+          metadata:
+            name: apihub-related
+            labels:
+              apihub-source: generate-animal-apis
+          data:
+            displayName: Related Resources
+            description: Links to resources in the registry.
+            references:
+              - id: fauna-whales
+                displayName: fauna-whales
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/fauna-whales
+                uri: ""
+              - id: apigee-apihub-demo-petstore-product
+                displayName: 'apigee-apihub-demo product: petstore'
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-qd67qg2r5rb26dpl6so6oqxzmrrpuls3
+                uri: ""
         - kind: ReferenceList
           metadata:
             name: apihub-dependencies
@@ -53,7 +72,7 @@ items:
         organization: apigee-apihub-demo
         product: petstore
     data:
-      displayName: 'apigee-apihub-demo product: fauna-whales'
+      displayName: Product apigee-apihub-demo-fauna-whales
       artifacts:
         - kind: ReferenceList
           metadata:
@@ -66,12 +85,12 @@ items:
             references:
               - id: fauna-whales
                 displayName: fauna-whales
-                category: enrollment
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-whales
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: proxy
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-meympzg77jgctttyelpmw2drvivwnh32
                 uri: ""
         - kind: ReferenceList

--- a/runtime/whales/info.yaml
+++ b/runtime/whales/info.yaml
@@ -7,6 +7,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
+        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-whales
@@ -46,6 +47,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
+        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/xeruses/info.yaml
+++ b/runtime/xeruses/info.yaml
@@ -7,6 +7,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
+        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-xeruses
@@ -46,6 +47,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
+        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/xeruses/info.yaml
+++ b/runtime/xeruses/info.yaml
@@ -7,7 +7,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
-        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-xeruses
@@ -66,7 +65,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
-        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/xeruses/info.yaml
+++ b/runtime/xeruses/info.yaml
@@ -12,7 +12,7 @@ items:
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-xeruses
     data:
-      displayName: 'apigee-apihub-demo proxy: fauna-xeruses'
+      displayName: Proxy apigee-apihub-demo-fauna-xeruses
       recommendedVersion: v1
       deployments:
         - metadata:
@@ -31,6 +31,25 @@ items:
             displayName: test-env (bar.org)
             endpointURI: bar.org
       artifacts:
+        - kind: ReferenceList
+          metadata:
+            name: apihub-related
+            labels:
+              apihub-source: generate-animal-apis
+          data:
+            displayName: Related Resources
+            description: Links to resources in the registry.
+            references:
+              - id: fauna-xeruses
+                displayName: fauna-xeruses
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/fauna-xeruses
+                uri: ""
+              - id: apigee-apihub-demo-petstore-product
+                displayName: 'apigee-apihub-demo product: petstore'
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-dzbf5iqnsa5pmybpzhvyd354dqygra2h
+                uri: ""
         - kind: ReferenceList
           metadata:
             name: apihub-dependencies
@@ -53,7 +72,7 @@ items:
         organization: apigee-apihub-demo
         product: petstore
     data:
-      displayName: 'apigee-apihub-demo product: fauna-xeruses'
+      displayName: Product apigee-apihub-demo-fauna-xeruses
       artifacts:
         - kind: ReferenceList
           metadata:
@@ -66,12 +85,12 @@ items:
             references:
               - id: fauna-xeruses
                 displayName: fauna-xeruses
-                category: enrollment
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-xeruses
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: proxy
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-by2ldivjoz3ph4sodohvvswbodiqfipf
                 uri: ""
         - kind: ReferenceList

--- a/runtime/yaks/info.yaml
+++ b/runtime/yaks/info.yaml
@@ -12,7 +12,7 @@ items:
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-yaks
     data:
-      displayName: 'apigee-apihub-demo proxy: fauna-yaks'
+      displayName: Proxy apigee-apihub-demo-fauna-yaks
       recommendedVersion: v1
       deployments:
         - metadata:
@@ -31,6 +31,25 @@ items:
             displayName: test-env (bar.org)
             endpointURI: bar.org
       artifacts:
+        - kind: ReferenceList
+          metadata:
+            name: apihub-related
+            labels:
+              apihub-source: generate-animal-apis
+          data:
+            displayName: Related Resources
+            description: Links to resources in the registry.
+            references:
+              - id: fauna-yaks
+                displayName: fauna-yaks
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/fauna-yaks
+                uri: ""
+              - id: apigee-apihub-demo-petstore-product
+                displayName: 'apigee-apihub-demo product: petstore'
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-wj6xirle4so5yan2uz2em3otif24vh2a
+                uri: ""
         - kind: ReferenceList
           metadata:
             name: apihub-dependencies
@@ -53,7 +72,7 @@ items:
         organization: apigee-apihub-demo
         product: petstore
     data:
-      displayName: 'apigee-apihub-demo product: fauna-yaks'
+      displayName: Product apigee-apihub-demo-fauna-yaks
       artifacts:
         - kind: ReferenceList
           metadata:
@@ -66,12 +85,12 @@ items:
             references:
               - id: fauna-yaks
                 displayName: fauna-yaks
-                category: enrollment
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-yaks
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: proxy
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-uaw2dsgdsmajo42kl6b3c2oncdxqydd4
                 uri: ""
         - kind: ReferenceList

--- a/runtime/yaks/info.yaml
+++ b/runtime/yaks/info.yaml
@@ -7,6 +7,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
+        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-yaks
@@ -46,6 +47,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
+        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/yaks/info.yaml
+++ b/runtime/yaks/info.yaml
@@ -7,7 +7,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
-        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-yaks
@@ -66,7 +65,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
-        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/zebras/info.yaml
+++ b/runtime/zebras/info.yaml
@@ -7,7 +7,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
-        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-zebras
@@ -66,7 +65,6 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
-        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/runtime/zebras/info.yaml
+++ b/runtime/zebras/info.yaml
@@ -12,7 +12,7 @@ items:
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-zebras
     data:
-      displayName: 'apigee-apihub-demo proxy: fauna-zebras'
+      displayName: Proxy apigee-apihub-demo-fauna-zebras
       recommendedVersion: v1
       deployments:
         - metadata:
@@ -31,6 +31,25 @@ items:
             displayName: test-env (bar.org)
             endpointURI: bar.org
       artifacts:
+        - kind: ReferenceList
+          metadata:
+            name: apihub-related
+            labels:
+              apihub-source: generate-animal-apis
+          data:
+            displayName: Related Resources
+            description: Links to resources in the registry.
+            references:
+              - id: fauna-zebras
+                displayName: fauna-zebras
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/fauna-zebras
+                uri: ""
+              - id: apigee-apihub-demo-petstore-product
+                displayName: 'apigee-apihub-demo product: petstore'
+                category: apihub-organization-apis
+                resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-2p6xarpy5pgnoxtv7siv33ks5pyq2fkw
+                uri: ""
         - kind: ReferenceList
           metadata:
             name: apihub-dependencies
@@ -53,7 +72,7 @@ items:
         organization: apigee-apihub-demo
         product: petstore
     data:
-      displayName: 'apigee-apihub-demo product: fauna-zebras'
+      displayName: Product apigee-apihub-demo-fauna-zebras
       artifacts:
         - kind: ReferenceList
           metadata:
@@ -66,12 +85,12 @@ items:
             references:
               - id: fauna-zebras
                 displayName: fauna-zebras
-                category: enrollment
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/fauna-zebras
                 uri: ""
               - id: apigee-apihub-demo-petstore-proxy
                 displayName: 'apigee-apihub-demo proxy: petstore'
-                category: proxy
+                category: apihub-organization-apis
                 resource: projects/apigee-apihub-demo/locations/global/apis/generate-animal-apis-5ezykm5hj5rstnhjdyn5m4usc4u6donf
                 uri: ""
         - kind: ReferenceList

--- a/runtime/zebras/info.yaml
+++ b/runtime/zebras/info.yaml
@@ -7,6 +7,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: proxy
+        apihub-lifecycle: observed-proxy
         apihub-source: generate-animal-apis
       annotations:
         proxy: apigee-apihub-demo/apis/fauna-zebras
@@ -46,6 +47,7 @@ items:
       labels:
         apihub-business-unit: apigee-apihub-demo
         apihub-kind: product
+        apihub-lifecycle: observed-product
         apihub-target-users: public
       annotations:
         organization: apigee-apihub-demo

--- a/traffic/000000/info.yaml
+++ b/traffic/000000/info.yaml
@@ -4,6 +4,7 @@ metadata:
   name: generate-animal-apis-67vfdqxjo4m3iq24obwm5usv4yz624kq
   labels:
     apihub-kind: traffic
+    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
 data:
   displayName: Traffic Observation 000000

--- a/traffic/000000/info.yaml
+++ b/traffic/000000/info.yaml
@@ -6,8 +6,11 @@ metadata:
     apihub-kind: traffic
     apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
+    apihub-target-users: internal
 data:
-  displayName: Traffic Observation 000000
+  displayName: Traffic 000000
+  recommendedVersion: v1
+  recommendedDeployment: example
   versions:
     - metadata:
         name: v1
@@ -16,6 +19,7 @@ data:
           apihub-source: generate-animal-apis
       data:
         displayName: v1
+        state: observed-traffic
         primarySpec: openapi
         specs:
           - metadata:
@@ -28,9 +32,12 @@ data:
               mimeType: application/x.openapi+gzip;version=3.0
   deployments:
     - metadata:
-        name: location
+        name: example
+        labels:
+          apihub-gateway: apihub-unmanaged
       data:
-        endpointURI: bar.org
+        displayName: example
+        endpointURI: https://example.com
   artifacts:
     - kind: ReferenceList
       metadata:
@@ -41,6 +48,6 @@ data:
         references:
           - id: fauna-aardvarks
             displayName: Enrolled API
-            category: enrollment
+            category: apihub-organization-apis
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-aardvarks
             uri: ""

--- a/traffic/000000/info.yaml
+++ b/traffic/000000/info.yaml
@@ -4,7 +4,6 @@ metadata:
   name: generate-animal-apis-67vfdqxjo4m3iq24obwm5usv4yz624kq
   labels:
     apihub-kind: traffic
-    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
     apihub-target-users: internal
 data:

--- a/traffic/000001/info.yaml
+++ b/traffic/000001/info.yaml
@@ -4,7 +4,6 @@ metadata:
   name: generate-animal-apis-v7l3npfi4rukklpr7uiplhuqxiio7q6k
   labels:
     apihub-kind: traffic
-    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
     apihub-target-users: internal
 data:

--- a/traffic/000001/info.yaml
+++ b/traffic/000001/info.yaml
@@ -4,6 +4,7 @@ metadata:
   name: generate-animal-apis-v7l3npfi4rukklpr7uiplhuqxiio7q6k
   labels:
     apihub-kind: traffic
+    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
 data:
   displayName: Traffic Observation 000001

--- a/traffic/000001/info.yaml
+++ b/traffic/000001/info.yaml
@@ -6,8 +6,11 @@ metadata:
     apihub-kind: traffic
     apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
+    apihub-target-users: internal
 data:
-  displayName: Traffic Observation 000001
+  displayName: Traffic 000001
+  recommendedVersion: v1
+  recommendedDeployment: example
   versions:
     - metadata:
         name: v1
@@ -16,6 +19,7 @@ data:
           apihub-source: generate-animal-apis
       data:
         displayName: v1
+        state: observed-traffic
         primarySpec: openapi
         specs:
           - metadata:
@@ -28,9 +32,12 @@ data:
               mimeType: application/x.openapi+gzip;version=3.0
   deployments:
     - metadata:
-        name: location
+        name: example
+        labels:
+          apihub-gateway: apihub-unmanaged
       data:
-        endpointURI: bar.org
+        displayName: example
+        endpointURI: https://example.com
   artifacts:
     - kind: ReferenceList
       metadata:
@@ -41,6 +48,6 @@ data:
         references:
           - id: fauna-bandicoots
             displayName: Enrolled API
-            category: enrollment
+            category: apihub-organization-apis
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-bandicoots
             uri: ""

--- a/traffic/000002/info.yaml
+++ b/traffic/000002/info.yaml
@@ -4,7 +4,6 @@ metadata:
   name: generate-animal-apis-nc6axd7wrcn4hyvr3ucvmaaubfbr5wb4
   labels:
     apihub-kind: traffic
-    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
     apihub-target-users: internal
 data:

--- a/traffic/000002/info.yaml
+++ b/traffic/000002/info.yaml
@@ -4,6 +4,7 @@ metadata:
   name: generate-animal-apis-nc6axd7wrcn4hyvr3ucvmaaubfbr5wb4
   labels:
     apihub-kind: traffic
+    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
 data:
   displayName: Traffic Observation 000002

--- a/traffic/000002/info.yaml
+++ b/traffic/000002/info.yaml
@@ -6,8 +6,11 @@ metadata:
     apihub-kind: traffic
     apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
+    apihub-target-users: internal
 data:
-  displayName: Traffic Observation 000002
+  displayName: Traffic 000002
+  recommendedVersion: v1
+  recommendedDeployment: example
   versions:
     - metadata:
         name: v1
@@ -16,6 +19,7 @@ data:
           apihub-source: generate-animal-apis
       data:
         displayName: v1
+        state: observed-traffic
         primarySpec: openapi
         specs:
           - metadata:
@@ -28,9 +32,12 @@ data:
               mimeType: application/x.openapi+gzip;version=3.0
   deployments:
     - metadata:
-        name: location
+        name: example
+        labels:
+          apihub-gateway: apihub-unmanaged
       data:
-        endpointURI: bar.org
+        displayName: example
+        endpointURI: https://example.com
   artifacts:
     - kind: ReferenceList
       metadata:
@@ -41,6 +48,6 @@ data:
         references:
           - id: fauna-crocodiles
             displayName: Enrolled API
-            category: enrollment
+            category: apihub-organization-apis
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-crocodiles
             uri: ""

--- a/traffic/000003/info.yaml
+++ b/traffic/000003/info.yaml
@@ -4,6 +4,7 @@ metadata:
   name: generate-animal-apis-q2pzvjnwwjrqu6kuxwjdsref2q4cb753
   labels:
     apihub-kind: traffic
+    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
 data:
   displayName: Traffic Observation 000003

--- a/traffic/000003/info.yaml
+++ b/traffic/000003/info.yaml
@@ -4,7 +4,6 @@ metadata:
   name: generate-animal-apis-q2pzvjnwwjrqu6kuxwjdsref2q4cb753
   labels:
     apihub-kind: traffic
-    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
     apihub-target-users: internal
 data:

--- a/traffic/000003/info.yaml
+++ b/traffic/000003/info.yaml
@@ -6,8 +6,11 @@ metadata:
     apihub-kind: traffic
     apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
+    apihub-target-users: internal
 data:
-  displayName: Traffic Observation 000003
+  displayName: Traffic 000003
+  recommendedVersion: v1
+  recommendedDeployment: example
   versions:
     - metadata:
         name: v1
@@ -16,6 +19,7 @@ data:
           apihub-source: generate-animal-apis
       data:
         displayName: v1
+        state: observed-traffic
         primarySpec: openapi
         specs:
           - metadata:
@@ -28,9 +32,12 @@ data:
               mimeType: application/x.openapi+gzip;version=3.0
   deployments:
     - metadata:
-        name: location
+        name: example
+        labels:
+          apihub-gateway: apihub-unmanaged
       data:
-        endpointURI: bar.org
+        displayName: example
+        endpointURI: https://example.com
   artifacts:
     - kind: ReferenceList
       metadata:
@@ -41,6 +48,6 @@ data:
         references:
           - id: fauna-dolphins
             displayName: Enrolled API
-            category: enrollment
+            category: apihub-organization-apis
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-dolphins
             uri: ""

--- a/traffic/000004/info.yaml
+++ b/traffic/000004/info.yaml
@@ -6,8 +6,11 @@ metadata:
     apihub-kind: traffic
     apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
+    apihub-target-users: internal
 data:
-  displayName: Traffic Observation 000004
+  displayName: Traffic 000004
+  recommendedVersion: v1
+  recommendedDeployment: example
   versions:
     - metadata:
         name: v1
@@ -16,6 +19,7 @@ data:
           apihub-source: generate-animal-apis
       data:
         displayName: v1
+        state: observed-traffic
         primarySpec: openapi
         specs:
           - metadata:
@@ -28,9 +32,12 @@ data:
               mimeType: application/x.openapi+gzip;version=3.0
   deployments:
     - metadata:
-        name: location
+        name: example
+        labels:
+          apihub-gateway: apihub-unmanaged
       data:
-        endpointURI: bar.org
+        displayName: example
+        endpointURI: https://example.com
   artifacts:
     - kind: ReferenceList
       metadata:
@@ -41,6 +48,6 @@ data:
         references:
           - id: fauna-elephants
             displayName: Enrolled API
-            category: enrollment
+            category: apihub-organization-apis
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-elephants
             uri: ""

--- a/traffic/000004/info.yaml
+++ b/traffic/000004/info.yaml
@@ -4,6 +4,7 @@ metadata:
   name: generate-animal-apis-3z6l6khjozuabub64dnliruxixgb4tew
   labels:
     apihub-kind: traffic
+    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
 data:
   displayName: Traffic Observation 000004

--- a/traffic/000004/info.yaml
+++ b/traffic/000004/info.yaml
@@ -4,7 +4,6 @@ metadata:
   name: generate-animal-apis-3z6l6khjozuabub64dnliruxixgb4tew
   labels:
     apihub-kind: traffic
-    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
     apihub-target-users: internal
 data:

--- a/traffic/000005/info.yaml
+++ b/traffic/000005/info.yaml
@@ -4,6 +4,7 @@ metadata:
   name: generate-animal-apis-ezyxkpbc7kbmpxdek44jsebarhakim72
   labels:
     apihub-kind: traffic
+    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
 data:
   displayName: Traffic Observation 000005

--- a/traffic/000005/info.yaml
+++ b/traffic/000005/info.yaml
@@ -4,7 +4,6 @@ metadata:
   name: generate-animal-apis-ezyxkpbc7kbmpxdek44jsebarhakim72
   labels:
     apihub-kind: traffic
-    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
     apihub-target-users: internal
 data:

--- a/traffic/000005/info.yaml
+++ b/traffic/000005/info.yaml
@@ -6,8 +6,11 @@ metadata:
     apihub-kind: traffic
     apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
+    apihub-target-users: internal
 data:
-  displayName: Traffic Observation 000005
+  displayName: Traffic 000005
+  recommendedVersion: v1
+  recommendedDeployment: example
   versions:
     - metadata:
         name: v1
@@ -16,6 +19,7 @@ data:
           apihub-source: generate-animal-apis
       data:
         displayName: v1
+        state: observed-traffic
         primarySpec: openapi
         specs:
           - metadata:
@@ -28,9 +32,12 @@ data:
               mimeType: application/x.openapi+gzip;version=3.0
   deployments:
     - metadata:
-        name: location
+        name: example
+        labels:
+          apihub-gateway: apihub-unmanaged
       data:
-        endpointURI: bar.org
+        displayName: example
+        endpointURI: https://example.com
   artifacts:
     - kind: ReferenceList
       metadata:
@@ -41,6 +48,6 @@ data:
         references:
           - id: fauna-flamingos
             displayName: Enrolled API
-            category: enrollment
+            category: apihub-organization-apis
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-flamingos
             uri: ""

--- a/traffic/000006/info.yaml
+++ b/traffic/000006/info.yaml
@@ -4,7 +4,6 @@ metadata:
   name: generate-animal-apis-4xpvle44z7c46ktqo2zidqdfnjr64fe2
   labels:
     apihub-kind: traffic
-    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
     apihub-target-users: internal
 data:

--- a/traffic/000006/info.yaml
+++ b/traffic/000006/info.yaml
@@ -4,6 +4,7 @@ metadata:
   name: generate-animal-apis-4xpvle44z7c46ktqo2zidqdfnjr64fe2
   labels:
     apihub-kind: traffic
+    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
 data:
   displayName: Traffic Observation 000006

--- a/traffic/000006/info.yaml
+++ b/traffic/000006/info.yaml
@@ -6,8 +6,11 @@ metadata:
     apihub-kind: traffic
     apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
+    apihub-target-users: internal
 data:
-  displayName: Traffic Observation 000006
+  displayName: Traffic 000006
+  recommendedVersion: v1
+  recommendedDeployment: example
   versions:
     - metadata:
         name: v1
@@ -16,6 +19,7 @@ data:
           apihub-source: generate-animal-apis
       data:
         displayName: v1
+        state: observed-traffic
         primarySpec: openapi
         specs:
           - metadata:
@@ -28,9 +32,12 @@ data:
               mimeType: application/x.openapi+gzip;version=3.0
   deployments:
     - metadata:
-        name: location
+        name: example
+        labels:
+          apihub-gateway: apihub-unmanaged
       data:
-        endpointURI: bar.org
+        displayName: example
+        endpointURI: https://example.com
   artifacts:
     - kind: ReferenceList
       metadata:
@@ -41,6 +48,6 @@ data:
         references:
           - id: fauna-giraffes
             displayName: Enrolled API
-            category: enrollment
+            category: apihub-organization-apis
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-giraffes
             uri: ""

--- a/traffic/000007/info.yaml
+++ b/traffic/000007/info.yaml
@@ -4,6 +4,7 @@ metadata:
   name: generate-animal-apis-aocey2476dwc5pjgehdhc2hxus3wd3sn
   labels:
     apihub-kind: traffic
+    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
 data:
   displayName: Traffic Observation 000007

--- a/traffic/000007/info.yaml
+++ b/traffic/000007/info.yaml
@@ -6,8 +6,11 @@ metadata:
     apihub-kind: traffic
     apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
+    apihub-target-users: internal
 data:
-  displayName: Traffic Observation 000007
+  displayName: Traffic 000007
+  recommendedVersion: v1
+  recommendedDeployment: example
   versions:
     - metadata:
         name: v1
@@ -16,6 +19,7 @@ data:
           apihub-source: generate-animal-apis
       data:
         displayName: v1
+        state: observed-traffic
         primarySpec: openapi
         specs:
           - metadata:
@@ -28,9 +32,12 @@ data:
               mimeType: application/x.openapi+gzip;version=3.0
   deployments:
     - metadata:
-        name: location
+        name: example
+        labels:
+          apihub-gateway: apihub-unmanaged
       data:
-        endpointURI: bar.org
+        displayName: example
+        endpointURI: https://example.com
   artifacts:
     - kind: ReferenceList
       metadata:
@@ -41,6 +48,6 @@ data:
         references:
           - id: fauna-hedgehogs
             displayName: Enrolled API
-            category: enrollment
+            category: apihub-organization-apis
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-hedgehogs
             uri: ""

--- a/traffic/000007/info.yaml
+++ b/traffic/000007/info.yaml
@@ -4,7 +4,6 @@ metadata:
   name: generate-animal-apis-aocey2476dwc5pjgehdhc2hxus3wd3sn
   labels:
     apihub-kind: traffic
-    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
     apihub-target-users: internal
 data:

--- a/traffic/000008/info.yaml
+++ b/traffic/000008/info.yaml
@@ -4,7 +4,6 @@ metadata:
   name: generate-animal-apis-kgxkjw34xa57hhj234urvdghvby4hj2r
   labels:
     apihub-kind: traffic
-    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
     apihub-target-users: internal
 data:

--- a/traffic/000008/info.yaml
+++ b/traffic/000008/info.yaml
@@ -4,6 +4,7 @@ metadata:
   name: generate-animal-apis-kgxkjw34xa57hhj234urvdghvby4hj2r
   labels:
     apihub-kind: traffic
+    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
 data:
   displayName: Traffic Observation 000008

--- a/traffic/000008/info.yaml
+++ b/traffic/000008/info.yaml
@@ -6,8 +6,11 @@ metadata:
     apihub-kind: traffic
     apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
+    apihub-target-users: internal
 data:
-  displayName: Traffic Observation 000008
+  displayName: Traffic 000008
+  recommendedVersion: v1
+  recommendedDeployment: example
   versions:
     - metadata:
         name: v1
@@ -16,6 +19,7 @@ data:
           apihub-source: generate-animal-apis
       data:
         displayName: v1
+        state: observed-traffic
         primarySpec: openapi
         specs:
           - metadata:
@@ -28,9 +32,12 @@ data:
               mimeType: application/x.openapi+gzip;version=3.0
   deployments:
     - metadata:
-        name: location
+        name: example
+        labels:
+          apihub-gateway: apihub-unmanaged
       data:
-        endpointURI: bar.org
+        displayName: example
+        endpointURI: https://example.com
   artifacts:
     - kind: ReferenceList
       metadata:
@@ -41,6 +48,6 @@ data:
         references:
           - id: fauna-iguanas
             displayName: Enrolled API
-            category: enrollment
+            category: apihub-organization-apis
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-iguanas
             uri: ""

--- a/traffic/000009/info.yaml
+++ b/traffic/000009/info.yaml
@@ -6,8 +6,11 @@ metadata:
     apihub-kind: traffic
     apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
+    apihub-target-users: internal
 data:
-  displayName: Traffic Observation 000009
+  displayName: Traffic 000009
+  recommendedVersion: v1
+  recommendedDeployment: example
   versions:
     - metadata:
         name: v1
@@ -16,6 +19,7 @@ data:
           apihub-source: generate-animal-apis
       data:
         displayName: v1
+        state: observed-traffic
         primarySpec: openapi
         specs:
           - metadata:
@@ -28,9 +32,12 @@ data:
               mimeType: application/x.openapi+gzip;version=3.0
   deployments:
     - metadata:
-        name: location
+        name: example
+        labels:
+          apihub-gateway: apihub-unmanaged
       data:
-        endpointURI: bar.org
+        displayName: example
+        endpointURI: https://example.com
   artifacts:
     - kind: ReferenceList
       metadata:
@@ -41,6 +48,6 @@ data:
         references:
           - id: fauna-jaguars
             displayName: Enrolled API
-            category: enrollment
+            category: apihub-organization-apis
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-jaguars
             uri: ""

--- a/traffic/000009/info.yaml
+++ b/traffic/000009/info.yaml
@@ -4,6 +4,7 @@ metadata:
   name: generate-animal-apis-c7zo43dlhltugncm5acplwo2ukkla7rj
   labels:
     apihub-kind: traffic
+    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
 data:
   displayName: Traffic Observation 000009

--- a/traffic/000009/info.yaml
+++ b/traffic/000009/info.yaml
@@ -4,7 +4,6 @@ metadata:
   name: generate-animal-apis-c7zo43dlhltugncm5acplwo2ukkla7rj
   labels:
     apihub-kind: traffic
-    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
     apihub-target-users: internal
 data:

--- a/traffic/000010/info.yaml
+++ b/traffic/000010/info.yaml
@@ -4,7 +4,6 @@ metadata:
   name: generate-animal-apis-rziiyurowlq4n4akwoaiws2unb3ygwc3
   labels:
     apihub-kind: traffic
-    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
     apihub-target-users: internal
 data:

--- a/traffic/000010/info.yaml
+++ b/traffic/000010/info.yaml
@@ -4,6 +4,7 @@ metadata:
   name: generate-animal-apis-rziiyurowlq4n4akwoaiws2unb3ygwc3
   labels:
     apihub-kind: traffic
+    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
 data:
   displayName: Traffic Observation 000010

--- a/traffic/000010/info.yaml
+++ b/traffic/000010/info.yaml
@@ -6,8 +6,11 @@ metadata:
     apihub-kind: traffic
     apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
+    apihub-target-users: internal
 data:
-  displayName: Traffic Observation 000010
+  displayName: Traffic 000010
+  recommendedVersion: v1
+  recommendedDeployment: example
   versions:
     - metadata:
         name: v1
@@ -16,6 +19,7 @@ data:
           apihub-source: generate-animal-apis
       data:
         displayName: v1
+        state: observed-traffic
         primarySpec: openapi
         specs:
           - metadata:
@@ -28,9 +32,12 @@ data:
               mimeType: application/x.openapi+gzip;version=3.0
   deployments:
     - metadata:
-        name: location
+        name: example
+        labels:
+          apihub-gateway: apihub-unmanaged
       data:
-        endpointURI: bar.org
+        displayName: example
+        endpointURI: https://example.com
   artifacts:
     - kind: ReferenceList
       metadata:
@@ -41,6 +48,6 @@ data:
         references:
           - id: fauna-kangaroos
             displayName: Enrolled API
-            category: enrollment
+            category: apihub-organization-apis
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-kangaroos
             uri: ""

--- a/traffic/000011/info.yaml
+++ b/traffic/000011/info.yaml
@@ -6,8 +6,11 @@ metadata:
     apihub-kind: traffic
     apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
+    apihub-target-users: internal
 data:
-  displayName: Traffic Observation 000011
+  displayName: Traffic 000011
+  recommendedVersion: v1
+  recommendedDeployment: example
   versions:
     - metadata:
         name: v1
@@ -16,6 +19,7 @@ data:
           apihub-source: generate-animal-apis
       data:
         displayName: v1
+        state: observed-traffic
         primarySpec: openapi
         specs:
           - metadata:
@@ -28,9 +32,12 @@ data:
               mimeType: application/x.openapi+gzip;version=3.0
   deployments:
     - metadata:
-        name: location
+        name: example
+        labels:
+          apihub-gateway: apihub-unmanaged
       data:
-        endpointURI: bar.org
+        displayName: example
+        endpointURI: https://example.com
   artifacts:
     - kind: ReferenceList
       metadata:
@@ -41,6 +48,6 @@ data:
         references:
           - id: fauna-lemurs
             displayName: Enrolled API
-            category: enrollment
+            category: apihub-organization-apis
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-lemurs
             uri: ""

--- a/traffic/000011/info.yaml
+++ b/traffic/000011/info.yaml
@@ -4,6 +4,7 @@ metadata:
   name: generate-animal-apis-mnflmjrmplapzjyxd6dwepmnirorsx7i
   labels:
     apihub-kind: traffic
+    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
 data:
   displayName: Traffic Observation 000011

--- a/traffic/000011/info.yaml
+++ b/traffic/000011/info.yaml
@@ -4,7 +4,6 @@ metadata:
   name: generate-animal-apis-mnflmjrmplapzjyxd6dwepmnirorsx7i
   labels:
     apihub-kind: traffic
-    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
     apihub-target-users: internal
 data:

--- a/traffic/000012/info.yaml
+++ b/traffic/000012/info.yaml
@@ -6,8 +6,11 @@ metadata:
     apihub-kind: traffic
     apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
+    apihub-target-users: internal
 data:
-  displayName: Traffic Observation 000012
+  displayName: Traffic 000012
+  recommendedVersion: v1
+  recommendedDeployment: example
   versions:
     - metadata:
         name: v1
@@ -16,6 +19,7 @@ data:
           apihub-source: generate-animal-apis
       data:
         displayName: v1
+        state: observed-traffic
         primarySpec: openapi
         specs:
           - metadata:
@@ -28,9 +32,12 @@ data:
               mimeType: application/x.openapi+gzip;version=3.0
   deployments:
     - metadata:
-        name: location
+        name: example
+        labels:
+          apihub-gateway: apihub-unmanaged
       data:
-        endpointURI: bar.org
+        displayName: example
+        endpointURI: https://example.com
   artifacts:
     - kind: ReferenceList
       metadata:
@@ -41,6 +48,6 @@ data:
         references:
           - id: fauna-monkeys
             displayName: Enrolled API
-            category: enrollment
+            category: apihub-organization-apis
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-monkeys
             uri: ""

--- a/traffic/000012/info.yaml
+++ b/traffic/000012/info.yaml
@@ -4,6 +4,7 @@ metadata:
   name: generate-animal-apis-o7xiwbs63mkuj6fekwg3qhtz7x3ngaa5
   labels:
     apihub-kind: traffic
+    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
 data:
   displayName: Traffic Observation 000012

--- a/traffic/000012/info.yaml
+++ b/traffic/000012/info.yaml
@@ -4,7 +4,6 @@ metadata:
   name: generate-animal-apis-o7xiwbs63mkuj6fekwg3qhtz7x3ngaa5
   labels:
     apihub-kind: traffic
-    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
     apihub-target-users: internal
 data:

--- a/traffic/000013/info.yaml
+++ b/traffic/000013/info.yaml
@@ -4,7 +4,6 @@ metadata:
   name: generate-animal-apis-6t4govat3ni6dm6x27y3nedepmeetp36
   labels:
     apihub-kind: traffic
-    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
     apihub-target-users: internal
 data:

--- a/traffic/000013/info.yaml
+++ b/traffic/000013/info.yaml
@@ -4,6 +4,7 @@ metadata:
   name: generate-animal-apis-6t4govat3ni6dm6x27y3nedepmeetp36
   labels:
     apihub-kind: traffic
+    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
 data:
   displayName: Traffic Observation 000013

--- a/traffic/000013/info.yaml
+++ b/traffic/000013/info.yaml
@@ -6,8 +6,11 @@ metadata:
     apihub-kind: traffic
     apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
+    apihub-target-users: internal
 data:
-  displayName: Traffic Observation 000013
+  displayName: Traffic 000013
+  recommendedVersion: v1
+  recommendedDeployment: example
   versions:
     - metadata:
         name: v1
@@ -16,6 +19,7 @@ data:
           apihub-source: generate-animal-apis
       data:
         displayName: v1
+        state: observed-traffic
         primarySpec: openapi
         specs:
           - metadata:
@@ -28,9 +32,12 @@ data:
               mimeType: application/x.openapi+gzip;version=3.0
   deployments:
     - metadata:
-        name: location
+        name: example
+        labels:
+          apihub-gateway: apihub-unmanaged
       data:
-        endpointURI: bar.org
+        displayName: example
+        endpointURI: https://example.com
   artifacts:
     - kind: ReferenceList
       metadata:
@@ -41,6 +48,6 @@ data:
         references:
           - id: fauna-nightingales
             displayName: Enrolled API
-            category: enrollment
+            category: apihub-organization-apis
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-nightingales
             uri: ""

--- a/traffic/000014/info.yaml
+++ b/traffic/000014/info.yaml
@@ -4,6 +4,7 @@ metadata:
   name: generate-animal-apis-mhigjlduskzrlsfvlrn2uczpotqkelrj
   labels:
     apihub-kind: traffic
+    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
 data:
   displayName: Traffic Observation 000014

--- a/traffic/000014/info.yaml
+++ b/traffic/000014/info.yaml
@@ -6,8 +6,11 @@ metadata:
     apihub-kind: traffic
     apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
+    apihub-target-users: internal
 data:
-  displayName: Traffic Observation 000014
+  displayName: Traffic 000014
+  recommendedVersion: v1
+  recommendedDeployment: example
   versions:
     - metadata:
         name: v1
@@ -16,6 +19,7 @@ data:
           apihub-source: generate-animal-apis
       data:
         displayName: v1
+        state: observed-traffic
         primarySpec: openapi
         specs:
           - metadata:
@@ -28,9 +32,12 @@ data:
               mimeType: application/x.openapi+gzip;version=3.0
   deployments:
     - metadata:
-        name: location
+        name: example
+        labels:
+          apihub-gateway: apihub-unmanaged
       data:
-        endpointURI: bar.org
+        displayName: example
+        endpointURI: https://example.com
   artifacts:
     - kind: ReferenceList
       metadata:
@@ -41,6 +48,6 @@ data:
         references:
           - id: fauna-ostriches
             displayName: Enrolled API
-            category: enrollment
+            category: apihub-organization-apis
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-ostriches
             uri: ""

--- a/traffic/000014/info.yaml
+++ b/traffic/000014/info.yaml
@@ -4,7 +4,6 @@ metadata:
   name: generate-animal-apis-mhigjlduskzrlsfvlrn2uczpotqkelrj
   labels:
     apihub-kind: traffic
-    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
     apihub-target-users: internal
 data:

--- a/traffic/000015/info.yaml
+++ b/traffic/000015/info.yaml
@@ -6,8 +6,11 @@ metadata:
     apihub-kind: traffic
     apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
+    apihub-target-users: internal
 data:
-  displayName: Traffic Observation 000015
+  displayName: Traffic 000015
+  recommendedVersion: v1
+  recommendedDeployment: example
   versions:
     - metadata:
         name: v1
@@ -16,6 +19,7 @@ data:
           apihub-source: generate-animal-apis
       data:
         displayName: v1
+        state: observed-traffic
         primarySpec: openapi
         specs:
           - metadata:
@@ -28,9 +32,12 @@ data:
               mimeType: application/x.openapi+gzip;version=3.0
   deployments:
     - metadata:
-        name: location
+        name: example
+        labels:
+          apihub-gateway: apihub-unmanaged
       data:
-        endpointURI: bar.org
+        displayName: example
+        endpointURI: https://example.com
   artifacts:
     - kind: ReferenceList
       metadata:
@@ -41,6 +48,6 @@ data:
         references:
           - id: fauna-porcupines
             displayName: Enrolled API
-            category: enrollment
+            category: apihub-organization-apis
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-porcupines
             uri: ""

--- a/traffic/000015/info.yaml
+++ b/traffic/000015/info.yaml
@@ -4,7 +4,6 @@ metadata:
   name: generate-animal-apis-mmfcx3x267dwvk3ytuuh5rd6aenu3ahe
   labels:
     apihub-kind: traffic
-    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
     apihub-target-users: internal
 data:

--- a/traffic/000015/info.yaml
+++ b/traffic/000015/info.yaml
@@ -4,6 +4,7 @@ metadata:
   name: generate-animal-apis-mmfcx3x267dwvk3ytuuh5rd6aenu3ahe
   labels:
     apihub-kind: traffic
+    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
 data:
   displayName: Traffic Observation 000015

--- a/traffic/000016/info.yaml
+++ b/traffic/000016/info.yaml
@@ -4,6 +4,7 @@ metadata:
   name: generate-animal-apis-kqgvbytugv2qlpwqzxybuz7uspbfvyee
   labels:
     apihub-kind: traffic
+    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
 data:
   displayName: Traffic Observation 000016

--- a/traffic/000016/info.yaml
+++ b/traffic/000016/info.yaml
@@ -4,7 +4,6 @@ metadata:
   name: generate-animal-apis-kqgvbytugv2qlpwqzxybuz7uspbfvyee
   labels:
     apihub-kind: traffic
-    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
     apihub-target-users: internal
 data:

--- a/traffic/000016/info.yaml
+++ b/traffic/000016/info.yaml
@@ -6,8 +6,11 @@ metadata:
     apihub-kind: traffic
     apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
+    apihub-target-users: internal
 data:
-  displayName: Traffic Observation 000016
+  displayName: Traffic 000016
+  recommendedVersion: v1
+  recommendedDeployment: example
   versions:
     - metadata:
         name: v1
@@ -16,6 +19,7 @@ data:
           apihub-source: generate-animal-apis
       data:
         displayName: v1
+        state: observed-traffic
         primarySpec: openapi
         specs:
           - metadata:
@@ -28,9 +32,12 @@ data:
               mimeType: application/x.openapi+gzip;version=3.0
   deployments:
     - metadata:
-        name: location
+        name: example
+        labels:
+          apihub-gateway: apihub-unmanaged
       data:
-        endpointURI: bar.org
+        displayName: example
+        endpointURI: https://example.com
   artifacts:
     - kind: ReferenceList
       metadata:
@@ -41,6 +48,6 @@ data:
         references:
           - id: fauna-quokkas
             displayName: Enrolled API
-            category: enrollment
+            category: apihub-organization-apis
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-quokkas
             uri: ""

--- a/traffic/000017/info.yaml
+++ b/traffic/000017/info.yaml
@@ -4,6 +4,7 @@ metadata:
   name: generate-animal-apis-rkoqazzuyjxbockg57duyrjpjo4unutx
   labels:
     apihub-kind: traffic
+    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
 data:
   displayName: Traffic Observation 000017

--- a/traffic/000017/info.yaml
+++ b/traffic/000017/info.yaml
@@ -6,8 +6,11 @@ metadata:
     apihub-kind: traffic
     apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
+    apihub-target-users: internal
 data:
-  displayName: Traffic Observation 000017
+  displayName: Traffic 000017
+  recommendedVersion: v1
+  recommendedDeployment: example
   versions:
     - metadata:
         name: v1
@@ -16,6 +19,7 @@ data:
           apihub-source: generate-animal-apis
       data:
         displayName: v1
+        state: observed-traffic
         primarySpec: openapi
         specs:
           - metadata:
@@ -28,9 +32,12 @@ data:
               mimeType: application/x.openapi+gzip;version=3.0
   deployments:
     - metadata:
-        name: location
+        name: example
+        labels:
+          apihub-gateway: apihub-unmanaged
       data:
-        endpointURI: bar.org
+        displayName: example
+        endpointURI: https://example.com
   artifacts:
     - kind: ReferenceList
       metadata:
@@ -41,6 +48,6 @@ data:
         references:
           - id: fauna-raccoons
             displayName: Enrolled API
-            category: enrollment
+            category: apihub-organization-apis
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-raccoons
             uri: ""

--- a/traffic/000017/info.yaml
+++ b/traffic/000017/info.yaml
@@ -4,7 +4,6 @@ metadata:
   name: generate-animal-apis-rkoqazzuyjxbockg57duyrjpjo4unutx
   labels:
     apihub-kind: traffic
-    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
     apihub-target-users: internal
 data:

--- a/traffic/000018/info.yaml
+++ b/traffic/000018/info.yaml
@@ -4,7 +4,6 @@ metadata:
   name: generate-animal-apis-axj2wd3gsm2holwoz2qjdivjthwgppri
   labels:
     apihub-kind: traffic
-    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
     apihub-target-users: internal
 data:

--- a/traffic/000018/info.yaml
+++ b/traffic/000018/info.yaml
@@ -4,6 +4,7 @@ metadata:
   name: generate-animal-apis-axj2wd3gsm2holwoz2qjdivjthwgppri
   labels:
     apihub-kind: traffic
+    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
 data:
   displayName: Traffic Observation 000018

--- a/traffic/000018/info.yaml
+++ b/traffic/000018/info.yaml
@@ -6,8 +6,11 @@ metadata:
     apihub-kind: traffic
     apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
+    apihub-target-users: internal
 data:
-  displayName: Traffic Observation 000018
+  displayName: Traffic 000018
+  recommendedVersion: v1
+  recommendedDeployment: example
   versions:
     - metadata:
         name: v1
@@ -16,6 +19,7 @@ data:
           apihub-source: generate-animal-apis
       data:
         displayName: v1
+        state: observed-traffic
         primarySpec: openapi
         specs:
           - metadata:
@@ -28,9 +32,12 @@ data:
               mimeType: application/x.openapi+gzip;version=3.0
   deployments:
     - metadata:
-        name: location
+        name: example
+        labels:
+          apihub-gateway: apihub-unmanaged
       data:
-        endpointURI: bar.org
+        displayName: example
+        endpointURI: https://example.com
   artifacts:
     - kind: ReferenceList
       metadata:
@@ -41,6 +48,6 @@ data:
         references:
           - id: fauna-salamanders
             displayName: Enrolled API
-            category: enrollment
+            category: apihub-organization-apis
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-salamanders
             uri: ""

--- a/traffic/000019/info.yaml
+++ b/traffic/000019/info.yaml
@@ -4,7 +4,6 @@ metadata:
   name: generate-animal-apis-fntt5xwrjvij3f6xxmwa77gnlvfmwo6k
   labels:
     apihub-kind: traffic
-    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
     apihub-target-users: internal
 data:

--- a/traffic/000019/info.yaml
+++ b/traffic/000019/info.yaml
@@ -4,6 +4,7 @@ metadata:
   name: generate-animal-apis-fntt5xwrjvij3f6xxmwa77gnlvfmwo6k
   labels:
     apihub-kind: traffic
+    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
 data:
   displayName: Traffic Observation 000019

--- a/traffic/000019/info.yaml
+++ b/traffic/000019/info.yaml
@@ -6,8 +6,11 @@ metadata:
     apihub-kind: traffic
     apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
+    apihub-target-users: internal
 data:
-  displayName: Traffic Observation 000019
+  displayName: Traffic 000019
+  recommendedVersion: v1
+  recommendedDeployment: example
   versions:
     - metadata:
         name: v1
@@ -16,6 +19,7 @@ data:
           apihub-source: generate-animal-apis
       data:
         displayName: v1
+        state: observed-traffic
         primarySpec: openapi
         specs:
           - metadata:
@@ -28,9 +32,12 @@ data:
               mimeType: application/x.openapi+gzip;version=3.0
   deployments:
     - metadata:
-        name: location
+        name: example
+        labels:
+          apihub-gateway: apihub-unmanaged
       data:
-        endpointURI: bar.org
+        displayName: example
+        endpointURI: https://example.com
   artifacts:
     - kind: ReferenceList
       metadata:
@@ -41,6 +48,6 @@ data:
         references:
           - id: fauna-tortoises
             displayName: Enrolled API
-            category: enrollment
+            category: apihub-organization-apis
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-tortoises
             uri: ""

--- a/traffic/000020/info.yaml
+++ b/traffic/000020/info.yaml
@@ -6,8 +6,11 @@ metadata:
     apihub-kind: traffic
     apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
+    apihub-target-users: internal
 data:
-  displayName: Traffic Observation 000020
+  displayName: Traffic 000020
+  recommendedVersion: v1
+  recommendedDeployment: example
   versions:
     - metadata:
         name: v1
@@ -16,6 +19,7 @@ data:
           apihub-source: generate-animal-apis
       data:
         displayName: v1
+        state: observed-traffic
         primarySpec: openapi
         specs:
           - metadata:
@@ -28,9 +32,12 @@ data:
               mimeType: application/x.openapi+gzip;version=3.0
   deployments:
     - metadata:
-        name: location
+        name: example
+        labels:
+          apihub-gateway: apihub-unmanaged
       data:
-        endpointURI: bar.org
+        displayName: example
+        endpointURI: https://example.com
   artifacts:
     - kind: ReferenceList
       metadata:
@@ -41,6 +48,6 @@ data:
         references:
           - id: fauna-uakaris
             displayName: Enrolled API
-            category: enrollment
+            category: apihub-organization-apis
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-uakaris
             uri: ""

--- a/traffic/000020/info.yaml
+++ b/traffic/000020/info.yaml
@@ -4,7 +4,6 @@ metadata:
   name: generate-animal-apis-ml7pxbo4h2t6cou3yr7navtvife245qr
   labels:
     apihub-kind: traffic
-    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
     apihub-target-users: internal
 data:

--- a/traffic/000020/info.yaml
+++ b/traffic/000020/info.yaml
@@ -4,6 +4,7 @@ metadata:
   name: generate-animal-apis-ml7pxbo4h2t6cou3yr7navtvife245qr
   labels:
     apihub-kind: traffic
+    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
 data:
   displayName: Traffic Observation 000020

--- a/traffic/000021/info.yaml
+++ b/traffic/000021/info.yaml
@@ -6,8 +6,11 @@ metadata:
     apihub-kind: traffic
     apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
+    apihub-target-users: internal
 data:
-  displayName: Traffic Observation 000021
+  displayName: Traffic 000021
+  recommendedVersion: v1
+  recommendedDeployment: example
   versions:
     - metadata:
         name: v1
@@ -16,6 +19,7 @@ data:
           apihub-source: generate-animal-apis
       data:
         displayName: v1
+        state: observed-traffic
         primarySpec: openapi
         specs:
           - metadata:
@@ -28,9 +32,12 @@ data:
               mimeType: application/x.openapi+gzip;version=3.0
   deployments:
     - metadata:
-        name: location
+        name: example
+        labels:
+          apihub-gateway: apihub-unmanaged
       data:
-        endpointURI: bar.org
+        displayName: example
+        endpointURI: https://example.com
   artifacts:
     - kind: ReferenceList
       metadata:
@@ -41,6 +48,6 @@ data:
         references:
           - id: fauna-vultures
             displayName: Enrolled API
-            category: enrollment
+            category: apihub-organization-apis
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-vultures
             uri: ""

--- a/traffic/000021/info.yaml
+++ b/traffic/000021/info.yaml
@@ -4,6 +4,7 @@ metadata:
   name: generate-animal-apis-gzlg73t7aqp3pdahhsmyl44gmfqyxyp6
   labels:
     apihub-kind: traffic
+    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
 data:
   displayName: Traffic Observation 000021

--- a/traffic/000021/info.yaml
+++ b/traffic/000021/info.yaml
@@ -4,7 +4,6 @@ metadata:
   name: generate-animal-apis-gzlg73t7aqp3pdahhsmyl44gmfqyxyp6
   labels:
     apihub-kind: traffic
-    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
     apihub-target-users: internal
 data:

--- a/traffic/000022/info.yaml
+++ b/traffic/000022/info.yaml
@@ -4,7 +4,6 @@ metadata:
   name: generate-animal-apis-wbgqsn2fauctp3aedkn4pakrl3nbno66
   labels:
     apihub-kind: traffic
-    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
     apihub-target-users: internal
 data:

--- a/traffic/000022/info.yaml
+++ b/traffic/000022/info.yaml
@@ -6,8 +6,11 @@ metadata:
     apihub-kind: traffic
     apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
+    apihub-target-users: internal
 data:
-  displayName: Traffic Observation 000022
+  displayName: Traffic 000022
+  recommendedVersion: v1
+  recommendedDeployment: example
   versions:
     - metadata:
         name: v1
@@ -16,6 +19,7 @@ data:
           apihub-source: generate-animal-apis
       data:
         displayName: v1
+        state: observed-traffic
         primarySpec: openapi
         specs:
           - metadata:
@@ -28,9 +32,12 @@ data:
               mimeType: application/x.openapi+gzip;version=3.0
   deployments:
     - metadata:
-        name: location
+        name: example
+        labels:
+          apihub-gateway: apihub-unmanaged
       data:
-        endpointURI: bar.org
+        displayName: example
+        endpointURI: https://example.com
   artifacts:
     - kind: ReferenceList
       metadata:
@@ -41,6 +48,6 @@ data:
         references:
           - id: fauna-whales
             displayName: Enrolled API
-            category: enrollment
+            category: apihub-organization-apis
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-whales
             uri: ""

--- a/traffic/000022/info.yaml
+++ b/traffic/000022/info.yaml
@@ -4,6 +4,7 @@ metadata:
   name: generate-animal-apis-wbgqsn2fauctp3aedkn4pakrl3nbno66
   labels:
     apihub-kind: traffic
+    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
 data:
   displayName: Traffic Observation 000022

--- a/traffic/000023/info.yaml
+++ b/traffic/000023/info.yaml
@@ -4,6 +4,7 @@ metadata:
   name: generate-animal-apis-vsrgryxjobmpctlgoumn7yccigh4hmgq
   labels:
     apihub-kind: traffic
+    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
 data:
   displayName: Traffic Observation 000023

--- a/traffic/000023/info.yaml
+++ b/traffic/000023/info.yaml
@@ -6,8 +6,11 @@ metadata:
     apihub-kind: traffic
     apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
+    apihub-target-users: internal
 data:
-  displayName: Traffic Observation 000023
+  displayName: Traffic 000023
+  recommendedVersion: v1
+  recommendedDeployment: example
   versions:
     - metadata:
         name: v1
@@ -16,6 +19,7 @@ data:
           apihub-source: generate-animal-apis
       data:
         displayName: v1
+        state: observed-traffic
         primarySpec: openapi
         specs:
           - metadata:
@@ -28,9 +32,12 @@ data:
               mimeType: application/x.openapi+gzip;version=3.0
   deployments:
     - metadata:
-        name: location
+        name: example
+        labels:
+          apihub-gateway: apihub-unmanaged
       data:
-        endpointURI: bar.org
+        displayName: example
+        endpointURI: https://example.com
   artifacts:
     - kind: ReferenceList
       metadata:
@@ -41,6 +48,6 @@ data:
         references:
           - id: fauna-xeruses
             displayName: Enrolled API
-            category: enrollment
+            category: apihub-organization-apis
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-xeruses
             uri: ""

--- a/traffic/000023/info.yaml
+++ b/traffic/000023/info.yaml
@@ -4,7 +4,6 @@ metadata:
   name: generate-animal-apis-vsrgryxjobmpctlgoumn7yccigh4hmgq
   labels:
     apihub-kind: traffic
-    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
     apihub-target-users: internal
 data:

--- a/traffic/000024/info.yaml
+++ b/traffic/000024/info.yaml
@@ -4,6 +4,7 @@ metadata:
   name: generate-animal-apis-inckqsxnrwmaybjbgw6fq6fknotst5om
   labels:
     apihub-kind: traffic
+    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
 data:
   displayName: Traffic Observation 000024

--- a/traffic/000024/info.yaml
+++ b/traffic/000024/info.yaml
@@ -6,8 +6,11 @@ metadata:
     apihub-kind: traffic
     apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
+    apihub-target-users: internal
 data:
-  displayName: Traffic Observation 000024
+  displayName: Traffic 000024
+  recommendedVersion: v1
+  recommendedDeployment: example
   versions:
     - metadata:
         name: v1
@@ -16,6 +19,7 @@ data:
           apihub-source: generate-animal-apis
       data:
         displayName: v1
+        state: observed-traffic
         primarySpec: openapi
         specs:
           - metadata:
@@ -28,9 +32,12 @@ data:
               mimeType: application/x.openapi+gzip;version=3.0
   deployments:
     - metadata:
-        name: location
+        name: example
+        labels:
+          apihub-gateway: apihub-unmanaged
       data:
-        endpointURI: bar.org
+        displayName: example
+        endpointURI: https://example.com
   artifacts:
     - kind: ReferenceList
       metadata:
@@ -41,6 +48,6 @@ data:
         references:
           - id: fauna-yaks
             displayName: Enrolled API
-            category: enrollment
+            category: apihub-organization-apis
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-yaks
             uri: ""

--- a/traffic/000024/info.yaml
+++ b/traffic/000024/info.yaml
@@ -4,7 +4,6 @@ metadata:
   name: generate-animal-apis-inckqsxnrwmaybjbgw6fq6fknotst5om
   labels:
     apihub-kind: traffic
-    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
     apihub-target-users: internal
 data:

--- a/traffic/000025/info.yaml
+++ b/traffic/000025/info.yaml
@@ -4,7 +4,6 @@ metadata:
   name: generate-animal-apis-mslnyucoh3vp7dxmogeeprugksyipmtd
   labels:
     apihub-kind: traffic
-    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
     apihub-target-users: internal
 data:

--- a/traffic/000025/info.yaml
+++ b/traffic/000025/info.yaml
@@ -6,8 +6,11 @@ metadata:
     apihub-kind: traffic
     apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
+    apihub-target-users: internal
 data:
-  displayName: Traffic Observation 000025
+  displayName: Traffic 000025
+  recommendedVersion: v1
+  recommendedDeployment: example
   versions:
     - metadata:
         name: v1
@@ -16,6 +19,7 @@ data:
           apihub-source: generate-animal-apis
       data:
         displayName: v1
+        state: observed-traffic
         primarySpec: openapi
         specs:
           - metadata:
@@ -28,9 +32,12 @@ data:
               mimeType: application/x.openapi+gzip;version=3.0
   deployments:
     - metadata:
-        name: location
+        name: example
+        labels:
+          apihub-gateway: apihub-unmanaged
       data:
-        endpointURI: bar.org
+        displayName: example
+        endpointURI: https://example.com
   artifacts:
     - kind: ReferenceList
       metadata:
@@ -41,6 +48,6 @@ data:
         references:
           - id: fauna-zebras
             displayName: Enrolled API
-            category: enrollment
+            category: apihub-organization-apis
             resource: projects/apigee-apihub-demo/locations/global/apis/fauna-zebras
             uri: ""

--- a/traffic/000025/info.yaml
+++ b/traffic/000025/info.yaml
@@ -4,6 +4,7 @@ metadata:
   name: generate-animal-apis-mslnyucoh3vp7dxmogeeprugksyipmtd
   labels:
     apihub-kind: traffic
+    apihub-lifecycle: observed-traffic
     apihub-source: generate-animal-apis
 data:
   displayName: Traffic Observation 000025


### PR DESCRIPTION
Includes #15.

This adds several minor bits of additional information to the mock signals to improve their display in API Hub.

Also, because the resource references in the ReferenceList artifacts are currently expected to be absolute (and because API Hub silently fails to display references to resources outside the current project), the generate command takes a `--project` argument that should be the name of the GCP project where the API Hub instance is hosted. This defaults to `apigee-apihub-demo`. TODO: We should fix API Hub to allow project-relative references.