### PR TITLE
Add Cloud Run example with Cloud Endpoints (ESPv2) sidecar

### DIFF
--- a/examples/zebras-cloudrun/apis/DEPLOY.sh
+++ b/examples/zebras-cloudrun/apis/DEPLOY.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+gcloud endpoints services deploy zebras.json

--- a/examples/zebras-cloudrun/apis/zebras.json
+++ b/examples/zebras-cloudrun/apis/zebras.json
@@ -1,0 +1,186 @@
+{
+  "swagger": "2.0",
+  "host": "zebras.endpoints.apigee-apihub-demo.cloud.goog",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/",
+  "info": {
+    "version": "1.0.0",
+    "title": "Fauna Zebras API",
+    "description": "Manage collections of zebras.",
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    },
+    "contact": {
+      "name": "Zebras Support Team",
+      "email": "animals@apigee-apihub-demo.github.io",
+      "url": "https://github.com/apigee-apihub-demo/animals"
+    }
+  },
+  "paths": {
+    "/v1/zebras": {
+      "get": {
+        "summary": "List all zebras",
+        "description": "List all zebras",
+        "operationId": "listZebras",
+        "tags": [
+          "zebras"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "How many zebras to return at one time (max 100)",
+            "format": "int32",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A paged array of zebras",
+            "headers": {
+              "x-next": {
+                "description": "A link to the next page of responses",
+                "type": "string"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/Zebras"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        },
+        "produces": [
+          "application/json"
+        ]
+      },
+      "post": {
+        "summary": "Create zebras",
+        "description": "Create zebras",
+        "operationId": "createZebra",
+        "tags": [
+          "zebras"
+        ],
+        "responses": {
+          "201": {
+            "description": "Null response"
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pet",
+            "in": "body",
+            "description": "Pet to add to the store",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ]
+      }
+    },
+    "/v1/zebras/{zebraId}": {
+      "get": {
+        "summary": "Info for a specific zebra",
+        "description": "Info for a specific zebra",
+        "operationId": "getZebra",
+        "tags": [
+          "zebras"
+        ],
+        "parameters": [
+          {
+            "name": "zebraId",
+            "in": "path",
+            "description": "The id of the zebra to retrieve",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "schema": {
+              "$ref": "#/definitions/Zebra"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        },
+        "produces": [
+          "application/json"
+        ]
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "zebras",
+      "description": "This API is about zebras."
+    }
+  ],
+  "definitions": {
+    "Zebra": {
+      "type": "object",
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "Zebras": {
+      "type": "array",
+      "maxItems": 100,
+      "items": {
+        "$ref": "#/definitions/Zebra"
+      }
+    },
+    "Error": {
+      "type": "object",
+      "required": [
+        "code",
+        "message"
+      ],
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "x-components": {}
+}

--- a/examples/zebras-cloudrun/cloudrun/DEPLOY.sh
+++ b/examples/zebras-cloudrun/cloudrun/DEPLOY.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Deploy service and sidecar to Cloud Run.
+gcloud beta run services replace service.yaml --region us-west1
+
+# Allow all users to call the service (ESPv2 will manage access).
+gcloud run services set-iam-policy --region us-west1 zebras-example iam.yaml

--- a/examples/zebras-cloudrun/cloudrun/TEST.sh
+++ b/examples/zebras-cloudrun/cloudrun/TEST.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+export APP=https://zebras-example-y2k5eue77q-uw.a.run.app
+
+for i in {1..100}
+do
+
+echo
+echo $i: creating zebras
+curl $APP/v1/zebras -d '{"id":"1", "name":"alice"}'
+curl $APP/v1/zebras -d '{"id":"2", "name":"bob"}' 
+curl $APP/v1/zebras -d '{"id":"3", "name":"charley"}' 
+
+echo
+echo $i: fetching zebras
+curl $APP/v1/zebras
+
+echo
+echo $i: fetching zebra 2
+curl $APP/v1/zebras/2
+
+done

--- a/examples/zebras-cloudrun/cloudrun/iam.yaml
+++ b/examples/zebras-cloudrun/cloudrun/iam.yaml
@@ -1,0 +1,5 @@
+bindings:
+- members:
+  - allUsers
+  role: roles/run.invoker
+version: 1

--- a/examples/zebras-cloudrun/cloudrun/service.yaml
+++ b/examples/zebras-cloudrun/cloudrun/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: zebras-example
+spec:
+  template:
+    spec:
+      containers:
+      - image: gcr.io/endpoints-release/endpoints-runtime:2
+        name: espv2
+        args:
+        - --listener_port=8081
+        - --backend=http://localhost:8080
+        - --service=zebras.endpoints.apigee-apihub-demo.cloud.goog
+        - --rollout_strategy=managed
+        ports:
+        - name: http1
+          containerPort: 8081
+      - image: us-west1-docker.pkg.dev/apigee-apihub-demo/animals/animals:latest
+        name: animals

--- a/tools/GCR.sh
+++ b/tools/GCR.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+gcloud auth configure-docker us-west1-docker.pkg.dev
+
+docker build . --tag us-west1-docker.pkg.dev/apigee-apihub-demo/animals/animals:latest
+docker push us-west1-docker.pkg.dev/apigee-apihub-demo/animals/animals:latest


### PR DESCRIPTION
Using [Cloud Run sidecars](https://cloud.google.com/blog/products/serverless/cloud-run-now-supports-multi-container-deployments) allows us to make stunning simplifications to the [documented recommendations for using Cloud Endpoints with Cloud Run](https://cloud.google.com/endpoints/docs/openapi/set-up-cloud-run-espv2), which previously required a multi-step process including a trial deployment of a dummy image, a custom container build of the ESPv2 proxy, and two separate Cloud Run deployments to run the server image and the custom ESPv2 image.

Now all that is needed is:

1. Register our API with Service Infrastructure (`gcloud endpoints services deploy`)
2. Push a YAML file to Cloud Run that configures a container that runs our service alongside a container that runs ESPv2.

That's it. It's even simpler than using [API Gateway](https://cloud.google.com/api-gateway).